### PR TITLE
feat(ios-app): scaffold PTSA Board iOS app

### DIFF
--- a/ios-app/PTSABoard.xcodeproj/project.pbxproj
+++ b/ios-app/PTSABoard.xcodeproj/project.pbxproj
@@ -1,0 +1,376 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 77;
+	objects = {
+
+/* Begin PBXFileSystemSynchronizedRootGroup section */
+		A100000000000000000000A1 /* PTSABoard */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			explicitFileTypes = {};
+			explicitFolders = (
+			);
+			path = PTSABoard;
+			sourceTree = "<group>";
+		};
+/* End PBXFileSystemSynchronizedRootGroup section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		A100000000000000000000B1 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A100000000000000000000F1 /* MSAL in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		A100000000000000000000C0 = {
+			isa = PBXGroup;
+			children = (
+				A100000000000000000000A1 /* PTSABoard */,
+				A100000000000000000000C1 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		A100000000000000000000C1 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				A100000000000000000000D1 /* PTSABoard.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		A100000000000000000000D0 /* PTSABoard */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = A100000000000000000000E0 /* Build configuration list for PBXNativeTarget "PTSABoard" */;
+			buildPhases = (
+				A100000000000000000000B0 /* Sources */,
+				A100000000000000000000B1 /* Frameworks */,
+				A100000000000000000000B2 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				A100000000000000000000A1 /* PTSABoard */,
+			);
+			name = PTSABoard;
+			packageProductDependencies = (
+				A100000000000000000000F0 /* MSAL */,
+			);
+			productName = PTSABoard;
+			productReference = A100000000000000000000D1 /* PTSABoard.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		A100000000000000000000A0 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1600;
+				LastUpgradeCheck = 1600;
+				TargetAttributes = {
+					A100000000000000000000D0 = {
+						CreatedOnToolsVersion = 16.0;
+					};
+				};
+			};
+			buildConfigurationList = A100000000000000000000E1 /* Build configuration list for PBXProject "PTSABoard" */;
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = A100000000000000000000C0;
+			minimizedProjectReferenceProxies = 1;
+			packageReferences = (
+				A100000000000000000000F2 /* XCRemoteSwiftPackageReference "microsoft-authentication-library-for-objc" */,
+			);
+			preferredProjectObjectVersion = 77;
+			productRefGroup = A100000000000000000000C1 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				A100000000000000000000D0 /* PTSABoard */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		A100000000000000000000B2 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		A100000000000000000000B0 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXFileReference section */
+		A100000000000000000000D1 /* PTSABoard.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = PTSABoard.app; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+
+/* Begin XCBuildConfiguration section */
+		A100000000000000000000E2 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		A100000000000000000000E3 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		A100000000000000000000E4 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "\"PTSABoard/Preview Content\"";
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = PTSABoard/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = "PTSA Board";
+				INFOPLIST_KEY_NSFaceIDUsageDescription = "Use Face ID to securely sign you in to PTSA Board.";
+				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "Used to attach product images to listings.";
+				INFOPLIST_KEY_NSCameraUsageDescription = "Used to take new product photos.";
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "net.wilderptsa.PTSABoard";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		A100000000000000000000E5 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "\"PTSABoard/Preview Content\"";
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = PTSABoard/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = "PTSA Board";
+				INFOPLIST_KEY_NSFaceIDUsageDescription = "Use Face ID to securely sign you in to PTSA Board.";
+				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "Used to attach product images to listings.";
+				INFOPLIST_KEY_NSCameraUsageDescription = "Used to take new product photos.";
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "net.wilderptsa.PTSABoard";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		A100000000000000000000E0 /* Build configuration list for PBXNativeTarget "PTSABoard" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A100000000000000000000E4 /* Debug */,
+				A100000000000000000000E5 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		A100000000000000000000E1 /* Build configuration list for PBXProject "PTSABoard" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A100000000000000000000E2 /* Debug */,
+				A100000000000000000000E3 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		A100000000000000000000F2 /* XCRemoteSwiftPackageReference "microsoft-authentication-library-for-objc" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/AzureAD/microsoft-authentication-library-for-objc.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.5.0;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		A100000000000000000000F0 /* MSAL */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = A100000000000000000000F2 /* XCRemoteSwiftPackageReference "microsoft-authentication-library-for-objc" */;
+			productName = MSAL;
+		};
+/* End XCSwiftPackageProductDependency section */
+
+/* Begin PBXBuildFile section */
+		A100000000000000000000F1 /* MSAL in Frameworks */ = {isa = PBXBuildFile; productRef = A100000000000000000000F0 /* MSAL */; };
+/* End PBXBuildFile section */
+	};
+	rootObject = A100000000000000000000A0 /* Project object */;
+}

--- a/ios-app/PTSABoard.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/ios-app/PTSABoard.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/ios-app/PTSABoard.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/ios-app/PTSABoard.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/ios-app/PTSABoard.xcodeproj/xcshareddata/xcschemes/PTSABoard.xcscheme
+++ b/ios-app/PTSABoard.xcodeproj/xcshareddata/xcschemes/PTSABoard.xcscheme
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1600"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A100000000000000000000D0"
+               BuildableName = "PTSABoard.app"
+               BlueprintName = "PTSABoard"
+               ReferencedContainer = "container:PTSABoard.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A100000000000000000000D0"
+            BuildableName = "PTSABoard.app"
+            BlueprintName = "PTSABoard"
+            ReferencedContainer = "container:PTSABoard.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A100000000000000000000D0"
+            BuildableName = "PTSABoard.app"
+            BlueprintName = "PTSABoard"
+            ReferencedContainer = "container:PTSABoard.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/ios-app/PTSABoard/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/ios-app/PTSABoard/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.420",
+          "green" : "0.247",
+          "red" : "0.075"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.612",
+          "green" : "0.420",
+          "red" : "0.231"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ios-app/PTSABoard/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/ios-app/PTSABoard/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,13 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ios-app/PTSABoard/Assets.xcassets/Contents.json
+++ b/ios-app/PTSABoard/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ios-app/PTSABoard/Config/AppConfig.swift
+++ b/ios-app/PTSABoard/Config/AppConfig.swift
@@ -1,0 +1,85 @@
+import Foundation
+
+/// Centralized configuration for the PTSA Board app.
+///
+/// Before shipping you MUST fill in the values below from your tenant /
+/// WordPress site. Most of these are intentionally NOT hardcoded as secrets
+/// in source — see `README.md` for how to wire them via a build-time
+/// `Config.xcconfig`, environment variables, or by editing this file
+/// directly during initial setup.
+enum AppConfig {
+
+    // MARK: - Microsoft Entra ID (Azure AD)
+
+    /// The Application (client) ID of the iOS app registration in Entra ID.
+    /// Register a new "Mobile and desktop" app in
+    /// https://entra.microsoft.com and paste its Application (client) ID here.
+    static let entraClientId: String = "REPLACE_WITH_CLIENT_ID"
+
+    /// The tenant ID (or "common"/"organizations") for the wilderptsa.net tenant.
+    /// Single-tenant is recommended: use the tenant GUID for wilderptsa.net.
+    static let entraTenantId: String = "REPLACE_WITH_TENANT_ID"
+
+    /// MSAL redirect URI — must match the Info.plist URL scheme AND the
+    /// "iOS / macOS" platform redirect URI in the app registration.
+    static let entraRedirectUri: String = "msauth.net.wilderptsa.PTSABoard://auth"
+
+    /// MSAL keychain access group (optional). Leave nil to use default.
+    static let entraKeychainGroup: String? = nil
+
+    /// Authority URL — `https://login.microsoftonline.com/<tenant>`.
+    static var entraAuthority: String {
+        return "https://login.microsoftonline.com/\(entraTenantId)"
+    }
+
+    /// The Microsoft Graph scopes the app needs. Calendar.ReadWrite.Shared
+    /// is required to write to Calendar@wilderptsa.net for users that have
+    /// write access; everyone else falls back to read.
+    static let graphScopes: [String] = [
+        "User.Read",
+        "Calendars.ReadWrite.Shared",
+        "Mail.Send",
+        "User.ReadBasic.All",
+        "openid",
+        "profile",
+        "offline_access"
+    ]
+
+    /// The shared mailbox / calendar that hosts the PTSA calendar.
+    static let sharedCalendarMailbox: String = "Calendar@wilderptsa.net"
+
+    // MARK: - WordPress / WooCommerce
+
+    /// The public URL of the WordPress site.
+    static let wordpressBaseURL: URL = URL(string: "https://wilderptsa.net")!
+
+    /// REST API base for WordPress core (users, etc).
+    static var wpRestBase: URL { wordpressBaseURL.appendingPathComponent("wp-json/wp/v2") }
+
+    /// REST API base for WooCommerce v3 (orders, products).
+    static var wcRestBase: URL { wordpressBaseURL.appendingPathComponent("wp-json/wc/v3") }
+
+    /// REST API base for the custom PTSA Tools endpoints we expose from
+    /// the WordPress plugin in this repo (todo list, password reset triggers,
+    /// auction-email triggers, etc).
+    static var ptsaRestBase: URL { wordpressBaseURL.appendingPathComponent("wp-json/ptsa/v1") }
+
+    /// WooCommerce REST authentication. Use a read/write WC API key generated
+    /// at WP Admin → WooCommerce → Settings → Advanced → REST API.
+    /// We send it as Basic auth over HTTPS.
+    static let wooConsumerKey: String = "REPLACE_WITH_CK"
+    static let wooConsumerSecret: String = "REPLACE_WITH_CS"
+
+    // MARK: - Authorization
+
+    /// Email addresses (case-insensitive) allowed to check off / complete
+    /// items on the technology backlog. Everyone in @wilderptsa.net can add
+    /// and view; only these users can mark items complete.
+    static let todoAdminEmails: Set<String> = [
+        "OWNER@wilderptsa.net".lowercased()
+    ]
+
+    /// The email domain that the app accepts. Logins for any other domain
+    /// are rejected after the MSAL handshake.
+    static let allowedEmailDomain: String = "wilderptsa.net"
+}

--- a/ios-app/PTSABoard/Info.plist
+++ b/ios-app/PTSABoard/Info.plist
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleURLTypes</key>
+    <array>
+        <dict>
+            <key>CFBundleTypeRole</key>
+            <string>Editor</string>
+            <key>CFBundleURLName</key>
+            <string>net.wilderptsa.PTSABoard.msal</string>
+            <key>CFBundleURLSchemes</key>
+            <array>
+                <string>msauth.net.wilderptsa.PTSABoard</string>
+            </array>
+        </dict>
+    </array>
+    <key>LSApplicationQueriesSchemes</key>
+    <array>
+        <string>msauthv2</string>
+        <string>msauthv3</string>
+    </array>
+    <key>NSAppTransportSecurity</key>
+    <dict>
+        <key>NSAllowsArbitraryLoads</key>
+        <false/>
+    </dict>
+    <key>UIBackgroundModes</key>
+    <array>
+        <string>fetch</string>
+    </array>
+</dict>
+</plist>

--- a/ios-app/PTSABoard/Models/CalendarEvent.swift
+++ b/ios-app/PTSABoard/Models/CalendarEvent.swift
@@ -1,0 +1,69 @@
+import Foundation
+
+/// Microsoft Graph Calendar event (subset of the OData entity we care about).
+struct GraphEvent: Codable, Identifiable, Hashable {
+    let id: String
+    var subject: String?
+    var bodyPreview: String?
+    var start: GraphDateTimeTZ
+    var end: GraphDateTimeTZ
+    var location: GraphLocation?
+    var isAllDay: Bool?
+    var organizer: GraphAttendee?
+    var attendees: [GraphAttendee]?
+    var webLink: String?
+
+    var startDate: Date? { start.asDate }
+    var endDate: Date?   { end.asDate }
+}
+
+struct GraphDateTimeTZ: Codable, Hashable {
+    var dateTime: String
+    var timeZone: String
+
+    /// Convert to a Swift Date by parsing the Graph-style string.
+    var asDate: Date? {
+        let fmt = ISO8601DateFormatter()
+        fmt.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        if let d = fmt.date(from: dateTime + (dateTime.hasSuffix("Z") ? "" : "Z")) {
+            return d
+        }
+        let fb = DateFormatter()
+        fb.locale = Locale(identifier: "en_US_POSIX")
+        fb.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSSSSS"
+        return fb.date(from: dateTime)
+    }
+}
+
+struct GraphLocation: Codable, Hashable {
+    var displayName: String?
+    var address: GraphAddress?
+}
+
+struct GraphAddress: Codable, Hashable {
+    var street: String?
+    var city: String?
+    var state: String?
+    var countryOrRegion: String?
+    var postalCode: String?
+}
+
+struct GraphAttendee: Codable, Hashable {
+    var emailAddress: GraphEmailAddress?
+    var type: String?
+    var status: GraphResponseStatus?
+}
+
+struct GraphEmailAddress: Codable, Hashable {
+    var name: String?
+    var address: String?
+}
+
+struct GraphResponseStatus: Codable, Hashable {
+    var response: String?
+    var time: String?
+}
+
+struct GraphEventList: Codable {
+    let value: [GraphEvent]
+}

--- a/ios-app/PTSABoard/Models/TodoItem.swift
+++ b/ios-app/PTSABoard/Models/TodoItem.swift
@@ -1,0 +1,56 @@
+import Foundation
+
+struct TodoItem: Codable, Identifiable, Hashable {
+    let id: Int
+    var title: String
+    var details: String?
+    var dueDate: Date?
+    var createdAt: Date
+    var createdByEmail: String
+    var createdByName: String?
+    var completed: Bool
+    var completedAt: Date?
+    var completedByEmail: String?
+    var priority: TodoPriority
+
+    init(
+        id: Int = Int(Date().timeIntervalSince1970 * 1000),
+        title: String,
+        details: String? = nil,
+        dueDate: Date? = nil,
+        createdAt: Date = Date(),
+        createdByEmail: String,
+        createdByName: String? = nil,
+        completed: Bool = false,
+        completedAt: Date? = nil,
+        completedByEmail: String? = nil,
+        priority: TodoPriority = .normal
+    ) {
+        self.id = id
+        self.title = title
+        self.details = details
+        self.dueDate = dueDate
+        self.createdAt = createdAt
+        self.createdByEmail = createdByEmail
+        self.createdByName = createdByName
+        self.completed = completed
+        self.completedAt = completedAt
+        self.completedByEmail = completedByEmail
+        self.priority = priority
+    }
+}
+
+enum TodoPriority: String, Codable, CaseIterable, Identifiable {
+    case low, normal, high
+    var id: String { rawValue }
+
+    var label: String { rawValue.capitalized }
+
+    var color: String {
+        switch self {
+        case .low:    return "#8E8E93"
+        case .normal: return "#007AFF"
+        case .high:   return "#FF3B30"
+        }
+    }
+}

--- a/ios-app/PTSABoard/Models/UserProfile.swift
+++ b/ios-app/PTSABoard/Models/UserProfile.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+struct UserProfile: Codable, Hashable {
+    let id: String
+    let displayName: String
+    let userPrincipalName: String
+    let mail: String?
+    let jobTitle: String?
+    let givenName: String?
+    let surname: String?
+
+    var email: String { mail ?? userPrincipalName }
+
+    var initials: String {
+        let parts = displayName.split(separator: " ").prefix(2)
+        let initials = parts.compactMap { $0.first }.map { String($0) }.joined()
+        return initials.isEmpty ? String(email.prefix(2)).uppercased() : initials.uppercased()
+    }
+
+    var isTodoAdmin: Bool {
+        AppConfig.todoAdminEmails.contains(email.lowercased())
+    }
+}

--- a/ios-app/PTSABoard/Models/WooCommerce.swift
+++ b/ios-app/PTSABoard/Models/WooCommerce.swift
@@ -1,0 +1,139 @@
+import Foundation
+
+// MARK: - Orders
+
+struct WCOrder: Codable, Identifiable, Hashable {
+    let id: Int
+    let number: String
+    let status: String
+    let currency: String
+    let date_created: String?
+    let date_modified: String?
+    let total: String
+    let customer_id: Int?
+    let billing: WCAddress?
+    let shipping: WCAddress?
+    let line_items: [WCLineItem]
+    let payment_method_title: String?
+    let customer_note: String?
+
+    var totalAmount: Double { Double(total) ?? 0 }
+
+    var customerName: String {
+        let b = billing
+        let first = b?.first_name ?? ""
+        let last = b?.last_name ?? ""
+        let name = "\(first) \(last)".trimmingCharacters(in: .whitespaces)
+        return name.isEmpty ? (b?.email ?? "Customer #\(customer_id ?? 0)") : name
+    }
+
+    var customerEmail: String? { billing?.email }
+
+    var displayStatus: String {
+        status.replacingOccurrences(of: "-", with: " ").capitalized
+    }
+}
+
+struct WCAddress: Codable, Hashable {
+    var first_name: String?
+    var last_name: String?
+    var address_1: String?
+    var address_2: String?
+    var city: String?
+    var state: String?
+    var postcode: String?
+    var country: String?
+    var email: String?
+    var phone: String?
+}
+
+struct WCLineItem: Codable, Identifiable, Hashable {
+    let id: Int
+    let name: String
+    let product_id: Int
+    let variation_id: Int?
+    let quantity: Int
+    let total: String
+    let sku: String?
+}
+
+// MARK: - Products
+
+struct WCProduct: Codable, Identifiable, Hashable {
+    var id: Int
+    var name: String
+    var slug: String? = nil
+    var permalink: String? = nil
+    var type: String           // simple, variable, grouped, external, auction, etc.
+    var status: String         // publish, draft, pending, private
+    var featured: Bool? = nil
+    var description: String? = nil
+    var short_description: String? = nil
+    var sku: String? = nil
+    var price: String? = nil
+    var regular_price: String? = nil
+    var sale_price: String? = nil
+    var on_sale: Bool? = nil
+    var manage_stock: Bool? = nil
+    var stock_quantity: Int? = nil
+    var stock_status: String? = nil
+    var weight: String? = nil
+    var dimensions: WCDimensions? = nil
+    var shipping_required: Bool? = nil
+    var shipping_taxable: Bool? = nil
+    var shipping_class: String? = nil
+    var tax_status: String? = nil   // taxable, shipping, none
+    var tax_class: String? = nil
+    var categories: [WCRef]? = nil
+    var tags: [WCRef]? = nil
+    var images: [WCImage]? = nil
+    var attributes: [WCAttribute]? = nil
+    var date_created: String? = nil
+    var date_modified: String? = nil
+
+    var primaryImageURL: URL? {
+        guard let src = images?.first?.src else { return nil }
+        return URL(string: src)
+    }
+
+    /// Friendly "type" label for the badge.
+    var typeLabel: String {
+        switch type.lowercased() {
+        case "simple":   return "Simple"
+        case "variable": return "Variable"
+        case "grouped":  return "Grouped"
+        case "external": return "External"
+        case "auction":  return "Auction"
+        case "donation": return "Donation"
+        default:         return type.capitalized
+        }
+    }
+}
+
+struct WCDimensions: Codable, Hashable {
+    var length: String? = nil
+    var width: String? = nil
+    var height: String? = nil
+}
+
+struct WCRef: Codable, Hashable, Identifiable {
+    let id: Int
+    let name: String
+    let slug: String?
+}
+
+struct WCImage: Codable, Hashable, Identifiable {
+    var id: Int?
+    var src: String
+    var name: String?
+    var alt: String?
+}
+
+struct WCAttribute: Codable, Hashable, Identifiable {
+    var id: Int
+    var name: String
+    var position: Int?
+    var visible: Bool?
+    var variation: Bool?
+    var options: [String]
+}

--- a/ios-app/PTSABoard/Models/WordPressUser.swift
+++ b/ios-app/PTSABoard/Models/WordPressUser.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+struct WPUser: Codable, Identifiable, Hashable {
+    let id: Int
+    let name: String
+    let username: String?
+    let first_name: String?
+    let last_name: String?
+    let email: String?
+    let roles: [String]?
+    let registered_date: String?
+    let avatar_urls: [String: String]?
+
+    var displayName: String {
+        if !name.isEmpty { return name }
+        let joined = [first_name, last_name].compactMap { $0 }.joined(separator: " ")
+        return joined.isEmpty ? (username ?? "User #\(id)") : joined
+    }
+
+    var avatarURL: URL? {
+        let preferred = ["96", "48", "24"]
+        for key in preferred {
+            if let u = avatar_urls?[key], let url = URL(string: u) {
+                return url
+            }
+        }
+        return nil
+    }
+
+    var roleLabel: String {
+        (roles ?? []).map { $0.replacingOccurrences(of: "_", with: " ").capitalized }.joined(separator: ", ")
+    }
+}

--- a/ios-app/PTSABoard/PTSABoardApp.swift
+++ b/ios-app/PTSABoard/PTSABoardApp.swift
@@ -1,0 +1,34 @@
+import SwiftUI
+import MSAL
+
+@main
+struct PTSABoardApp: App {
+
+    @StateObject private var auth = AuthService()
+    @StateObject private var theme = ThemeManager()
+
+    var body: some Scene {
+        WindowGroup {
+            RootView()
+                .environmentObject(auth)
+                .environmentObject(theme)
+                .preferredColorScheme(theme.preferred)
+                .tint(.accentColor)
+                .onOpenURL { url in
+                    MSALPublicClientApplication.handleMSALResponse(
+                        url,
+                        sourceApplication: nil
+                    )
+                }
+                .task {
+                    AuthDelegate.shared.tokenProvider = { [weak auth] in
+                        guard let auth else {
+                            throw APIError.notConfigured("AuthService")
+                        }
+                        return try await auth.graphAccessToken()
+                    }
+                    await auth.restoreSession()
+                }
+        }
+    }
+}

--- a/ios-app/PTSABoard/Preview Content/Preview Assets.xcassets/Contents.json
+++ b/ios-app/PTSABoard/Preview Content/Preview Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ios-app/PTSABoard/Services/APIClient.swift
+++ b/ios-app/PTSABoard/Services/APIClient.swift
@@ -1,0 +1,107 @@
+import Foundation
+
+enum APIError: LocalizedError {
+    case http(Int, String?)
+    case decode(String)
+    case transport(Error)
+    case notConfigured(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .http(let code, let body): return "HTTP \(code)\(body.map { ": \($0)" } ?? "")"
+        case .decode(let why):          return "Decoding failed: \(why)"
+        case .transport(let err):       return err.localizedDescription
+        case .notConfigured(let key):   return "Not configured: \(key)"
+        }
+    }
+}
+
+/// Lightweight URLSession-backed JSON client. Designed to be reused
+/// by WooCommerce, WordPress and Graph services.
+struct APIClient {
+
+    enum AuthMode {
+        case none
+        case bearer(token: String)
+        case basic(user: String, pass: String)
+    }
+
+    let session: URLSession
+
+    init(session: URLSession = .shared) { self.session = session }
+
+    func request<T: Decodable>(
+        _ url: URL,
+        method: String = "GET",
+        query: [URLQueryItem] = [],
+        body: Data? = nil,
+        contentType: String = "application/json",
+        auth: AuthMode = .none,
+        as type: T.Type = T.self,
+        decoder: JSONDecoder = APIClient.defaultDecoder
+    ) async throws -> T {
+        let data = try await raw(
+            url, method: method, query: query, body: body,
+            contentType: contentType, auth: auth
+        )
+        do { return try decoder.decode(T.self, from: data) }
+        catch {
+            let snippet = String(data: data.prefix(400), encoding: .utf8) ?? ""
+            throw APIError.decode("\(error) — body: \(snippet)")
+        }
+    }
+
+    @discardableResult
+    func raw(
+        _ url: URL,
+        method: String = "GET",
+        query: [URLQueryItem] = [],
+        body: Data? = nil,
+        contentType: String = "application/json",
+        auth: AuthMode = .none
+    ) async throws -> Data {
+        var comps = URLComponents(url: url, resolvingAgainstBaseURL: false)!
+        if !query.isEmpty {
+            var items = comps.queryItems ?? []
+            items.append(contentsOf: query)
+            comps.queryItems = items
+        }
+        var req = URLRequest(url: comps.url!)
+        req.httpMethod = method
+        req.httpBody = body
+        if body != nil { req.setValue(contentType, forHTTPHeaderField: "Content-Type") }
+        req.setValue("application/json", forHTTPHeaderField: "Accept")
+        req.setValue("PTSABoard-iOS/1.0", forHTTPHeaderField: "User-Agent")
+
+        switch auth {
+        case .none: break
+        case .bearer(let token):
+            req.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        case .basic(let user, let pass):
+            let raw = "\(user):\(pass)".data(using: .utf8) ?? Data()
+            req.setValue("Basic \(raw.base64EncodedString())", forHTTPHeaderField: "Authorization")
+        }
+
+        do {
+            let (data, resp) = try await session.data(for: req)
+            guard let http = resp as? HTTPURLResponse else {
+                throw APIError.transport(NSError(domain: "APIClient", code: -1))
+            }
+            guard (200..<300).contains(http.statusCode) else {
+                let snippet = String(data: data.prefix(800), encoding: .utf8)
+                throw APIError.http(http.statusCode, snippet)
+            }
+            return data
+        } catch let err as APIError {
+            throw err
+        } catch {
+            throw APIError.transport(error)
+        }
+    }
+
+    static let defaultDecoder: JSONDecoder = {
+        let d = JSONDecoder()
+        d.keyDecodingStrategy = .useDefaultKeys
+        return d
+    }()
+}

--- a/ios-app/PTSABoard/Services/AuthService.swift
+++ b/ios-app/PTSABoard/Services/AuthService.swift
@@ -1,0 +1,212 @@
+import Foundation
+import SwiftUI
+import MSAL
+
+/// Auth state machine for the app.
+enum AuthState: Equatable {
+    case loading
+    case signedOut
+    case locked        // we have a valid cached account, but biometrics not yet passed this session
+    case signedIn
+}
+
+@MainActor
+final class AuthService: ObservableObject {
+
+    // MARK: - Published state
+
+    @Published private(set) var state: AuthState = .loading
+    @Published private(set) var profile: UserProfile?
+    @Published private(set) var lastError: String?
+
+    // MARK: - MSAL
+
+    private var msal: MSALPublicClientApplication?
+    private var account: MSALAccount?
+    private var cachedAccessToken: String?
+    private var cachedTokenExpiry: Date?
+
+    // MARK: - Bootstrap
+
+    init() {
+        do {
+            let authority = try MSALAADAuthority(url: URL(string: AppConfig.entraAuthority)!)
+            let config = MSALPublicClientApplicationConfig(
+                clientId: AppConfig.entraClientId,
+                redirectUri: AppConfig.entraRedirectUri,
+                authority: authority
+            )
+            config.knownAuthorities = [authority]
+            self.msal = try MSALPublicClientApplication(configuration: config)
+        } catch {
+            self.lastError = "MSAL init failed: \(error.localizedDescription)"
+            self.msal = nil
+        }
+    }
+
+    // MARK: - Public API
+
+    /// Called on app launch to figure out where the user should land.
+    /// - If an MSAL account exists AND biometrics are available, route through `locked`.
+    /// - Else, if an account exists, attempt silent refresh and go `signedIn`.
+    /// - Else go `signedOut`.
+    func restoreSession() async {
+        guard let msal else { state = .signedOut; return }
+
+        let accounts = (try? msal.allAccounts()) ?? []
+        guard let acct = accounts.first else {
+            state = .signedOut
+            return
+        }
+        self.account = acct
+
+        if let cachedJson = KeychainService.getData("profile.json"),
+           let profile = try? JSONDecoder().decode(UserProfile.self, from: cachedJson) {
+            self.profile = profile
+        }
+
+        if BiometricService.available != .none,
+           KeychainService.get("biometricEnrolled") == "1" {
+            state = .locked
+        } else {
+            await refreshSilent()
+        }
+    }
+
+    /// First-time / explicit interactive sign in.
+    func signIn(presenter: UIViewController) async {
+        guard let msal else { lastError = "MSAL not initialized"; return }
+
+        let webParams = MSALWebviewParameters(authPresentationViewController: presenter)
+        let params = MSALInteractiveTokenParameters(
+            scopes: AppConfig.graphScopes,
+            webviewParameters: webParams
+        )
+        params.promptType = .selectAccount
+
+        do {
+            let result: MSALResult = try await withCheckedThrowingContinuation { cont in
+                msal.acquireToken(with: params) { res, err in
+                    if let res { cont.resume(returning: res) }
+                    else { cont.resume(throwing: err ?? NSError(domain: "MSAL", code: -1)) }
+                }
+            }
+
+            try await handleSuccessfulLogin(result: result, persistBiometric: true)
+        } catch {
+            self.lastError = "Sign-in failed: \(error.localizedDescription)"
+        }
+    }
+
+    /// Biometric unlock after the app has been killed/foregrounded.
+    func unlockWithBiometrics() async {
+        do {
+            try await BiometricService.authenticate(reason: "Unlock PTSA Board")
+            await refreshSilent()
+        } catch {
+            self.lastError = "Biometric unlock failed: \(error.localizedDescription)"
+        }
+    }
+
+    /// Sign out and forget cached tokens / biometric enrolment.
+    func signOut() async {
+        if let msal, let account {
+            try? msal.remove(account)
+        }
+        self.account = nil
+        self.profile = nil
+        self.cachedAccessToken = nil
+        self.cachedTokenExpiry = nil
+        KeychainService.clearAll()
+        state = .signedOut
+    }
+
+    /// Return a fresh access token for Microsoft Graph, refreshing silently if needed.
+    func graphAccessToken() async throws -> String {
+        if let token = cachedAccessToken,
+           let exp = cachedTokenExpiry,
+           exp.timeIntervalSinceNow > 60 {
+            return token
+        }
+        return try await acquireTokenSilent()
+    }
+
+    // MARK: - Internals
+
+    private func refreshSilent() async {
+        do {
+            _ = try await acquireTokenSilent()
+            state = .signedIn
+        } catch {
+            self.lastError = "Could not refresh session, please sign in again."
+            state = .signedOut
+        }
+    }
+
+    private func acquireTokenSilent() async throws -> String {
+        guard let msal, let account else {
+            throw NSError(domain: "AuthService", code: -10, userInfo: [
+                NSLocalizedDescriptionKey: "No MSAL account"
+            ])
+        }
+        let authority = try MSALAADAuthority(url: URL(string: AppConfig.entraAuthority)!)
+        let params = MSALSilentTokenParameters(scopes: AppConfig.graphScopes, account: account)
+        params.authority = authority
+
+        let result: MSALResult = try await withCheckedThrowingContinuation { cont in
+            msal.acquireTokenSilent(with: params) { res, err in
+                if let res { cont.resume(returning: res) }
+                else { cont.resume(throwing: err ?? NSError(domain: "MSAL", code: -2)) }
+            }
+        }
+
+        try await handleSuccessfulLogin(result: result, persistBiometric: false)
+        return result.accessToken
+    }
+
+    private func handleSuccessfulLogin(result: MSALResult, persistBiometric: Bool) async throws {
+        let email = result.account.username ?? ""
+        guard email.lowercased().hasSuffix("@\(AppConfig.allowedEmailDomain.lowercased())") else {
+            // Reject non-PTSA accounts
+            try? msal?.remove(result.account)
+            throw NSError(domain: "AuthService", code: -20, userInfo: [
+                NSLocalizedDescriptionKey: "Only @\(AppConfig.allowedEmailDomain) accounts may use this app."
+            ])
+        }
+
+        self.account = result.account
+        self.cachedAccessToken = result.accessToken
+        self.cachedTokenExpiry = result.expiresOn
+
+        // Fetch /me to populate profile
+        let me = try await GraphService.shared.fetchMe(accessToken: result.accessToken)
+        self.profile = me
+        if let data = try? JSONEncoder().encode(me) {
+            KeychainService.setData(data, for: "profile.json")
+        }
+
+        if persistBiometric, BiometricService.available != .none {
+            KeychainService.set("1", for: "biometricEnrolled")
+        }
+
+        state = .signedIn
+    }
+}
+
+/// Convenience for grabbing the current root view controller for MSAL.
+@MainActor
+enum TopController {
+    static func current() -> UIViewController? {
+        guard let scene = UIApplication.shared.connectedScenes
+            .compactMap({ $0 as? UIWindowScene })
+            .first(where: { $0.activationState == .foregroundActive }) ?? UIApplication.shared.connectedScenes.compactMap({ $0 as? UIWindowScene }).first,
+              let window = scene.windows.first(where: { $0.isKeyWindow }) ?? scene.windows.first
+        else { return nil }
+
+        var vc = window.rootViewController
+        while let presented = vc?.presentedViewController {
+            vc = presented
+        }
+        return vc
+    }
+}

--- a/ios-app/PTSABoard/Services/BiometricService.swift
+++ b/ios-app/PTSABoard/Services/BiometricService.swift
@@ -1,0 +1,50 @@
+import Foundation
+import LocalAuthentication
+
+enum BiometricService {
+
+    enum BiometricKind {
+        case faceID, touchID, opticID, none
+    }
+
+    static var available: BiometricKind {
+        let ctx = LAContext()
+        var err: NSError?
+        guard ctx.canEvaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, error: &err) else {
+            return .none
+        }
+        switch ctx.biometryType {
+        case .faceID:  return .faceID
+        case .touchID: return .touchID
+        case .opticID: return .opticID
+        default:       return .none
+        }
+    }
+
+    /// Prompt FaceID / TouchID. Falls back to device passcode if biometrics
+    /// fail/aren't enrolled.
+    @MainActor
+    static func authenticate(reason: String) async throws {
+        let ctx = LAContext()
+        ctx.localizedReason = reason
+        ctx.localizedFallbackTitle = "Use Passcode"
+
+        var err: NSError?
+        guard ctx.canEvaluatePolicy(.deviceOwnerAuthentication, error: &err) else {
+            throw err ?? NSError(domain: "Biometric", code: -1)
+        }
+
+        try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, Error>) in
+            ctx.evaluatePolicy(
+                .deviceOwnerAuthentication,
+                localizedReason: reason
+            ) { success, evalErr in
+                if success {
+                    cont.resume()
+                } else {
+                    cont.resume(throwing: evalErr ?? NSError(domain: "Biometric", code: -2))
+                }
+            }
+        }
+    }
+}

--- a/ios-app/PTSABoard/Services/GraphService.swift
+++ b/ios-app/PTSABoard/Services/GraphService.swift
@@ -1,0 +1,136 @@
+import Foundation
+
+/// Microsoft Graph helper. The shared instance is fine because each call
+/// receives a fresh access token from `AuthService.graphAccessToken()`.
+final class GraphService {
+
+    static let shared = GraphService()
+    private init() {}
+
+    private let api = APIClient()
+    private let graphRoot = URL(string: "https://graph.microsoft.com/v1.0")!
+
+    // MARK: - Me
+
+    func fetchMe(accessToken: String) async throws -> UserProfile {
+        let url = graphRoot.appendingPathComponent("me")
+        return try await api.request(
+            url, auth: .bearer(token: accessToken), as: UserProfile.self
+        )
+    }
+
+    // MARK: - Photo
+
+    func fetchMyPhoto(accessToken: String) async -> Data? {
+        let url = graphRoot.appendingPathComponent("me/photo/$value")
+        return try? await api.raw(url, auth: .bearer(token: accessToken))
+    }
+
+    // MARK: - Shared calendar
+
+    /// Read events from the shared mailbox (`Calendar@wilderptsa.net`) between
+    /// `from` and `to`. Uses Graph's `calendarView` endpoint via the shared user.
+    func sharedCalendarEvents(accessToken: String, from: Date, to: Date) async throws -> [GraphEvent] {
+        let isoFrom = ISO8601DateFormatter().string(from: from)
+        let isoTo = ISO8601DateFormatter().string(from: to)
+
+        let mailbox = AppConfig.sharedCalendarMailbox
+        let url = graphRoot
+            .appendingPathComponent("users/\(mailbox)/calendarView")
+
+        let resp: GraphEventList = try await api.request(
+            url,
+            query: [
+                URLQueryItem(name: "startDateTime", value: isoFrom),
+                URLQueryItem(name: "endDateTime", value: isoTo),
+                URLQueryItem(name: "$orderby", value: "start/dateTime"),
+                URLQueryItem(name: "$top", value: "200")
+            ],
+            auth: .bearer(token: accessToken),
+            as: GraphEventList.self
+        )
+        return resp.value
+    }
+
+    /// Create a new event on the shared calendar. Requires Calendars.ReadWrite.Shared.
+    /// Returns the freshly-created event with its server-assigned id.
+    func createSharedEvent(
+        accessToken: String,
+        subject: String,
+        bodyHTML: String,
+        start: Date,
+        end: Date,
+        timeZone: String = TimeZone.current.identifier,
+        isAllDay: Bool = false,
+        location: String? = nil
+    ) async throws -> GraphEvent {
+        let mailbox = AppConfig.sharedCalendarMailbox
+        let url = graphRoot.appendingPathComponent("users/\(mailbox)/events")
+
+        let fmt = ISO8601DateFormatter()
+        fmt.formatOptions = [.withInternetDateTime]
+
+        var payload: [String: Any] = [
+            "subject": subject,
+            "body": [
+                "contentType": "HTML",
+                "content": bodyHTML
+            ],
+            "start": [
+                "dateTime": fmt.string(from: start),
+                "timeZone": timeZone
+            ],
+            "end": [
+                "dateTime": fmt.string(from: end),
+                "timeZone": timeZone
+            ],
+            "isAllDay": isAllDay
+        ]
+        if let location, !location.isEmpty {
+            payload["location"] = ["displayName": location]
+        }
+
+        let body = try JSONSerialization.data(withJSONObject: payload)
+        return try await api.request(
+            url, method: "POST", body: body,
+            auth: .bearer(token: accessToken), as: GraphEvent.self
+        )
+    }
+
+    /// Send an email as the signed-in user.
+    func sendMail(
+        accessToken: String,
+        subject: String,
+        bodyHTML: String,
+        to: [String],
+        cc: [String] = []
+    ) async throws {
+        struct SendMailRequest: Encodable {
+            let message: Message
+            let saveToSentItems: Bool
+
+            struct Message: Encodable {
+                let subject: String
+                let body: Body
+                let toRecipients: [Recipient]
+                let ccRecipients: [Recipient]
+            }
+            struct Body: Encodable { let contentType: String; let content: String }
+            struct Recipient: Encodable { let emailAddress: Email }
+            struct Email: Encodable { let address: String }
+        }
+
+        let payload = SendMailRequest(
+            message: .init(
+                subject: subject,
+                body: .init(contentType: "HTML", content: bodyHTML),
+                toRecipients: to.map { .init(emailAddress: .init(address: $0)) },
+                ccRecipients: cc.map { .init(emailAddress: .init(address: $0)) }
+            ),
+            saveToSentItems: true
+        )
+        let url = graphRoot.appendingPathComponent("me/sendMail")
+        let body = try JSONEncoder().encode(payload)
+        _ = try await api.raw(url, method: "POST", body: body, auth: .bearer(token: accessToken))
+    }
+}

--- a/ios-app/PTSABoard/Services/KeychainService.swift
+++ b/ios-app/PTSABoard/Services/KeychainService.swift
@@ -1,0 +1,79 @@
+import Foundation
+import Security
+
+/// Minimal Keychain wrapper used for credentials we want to outlive
+/// the app process (Entra account identifier, cached profile JSON,
+/// biometric-gated lock flag, WooCommerce key cache, etc).
+enum KeychainService {
+
+    private static let service = "net.wilderptsa.PTSABoard"
+
+    @discardableResult
+    static func set(_ value: String, for key: String, biometricGate: Bool = false) -> Bool {
+        guard let data = value.data(using: .utf8) else { return false }
+        return setData(data, for: key, biometricGate: biometricGate)
+    }
+
+    @discardableResult
+    static func setData(_ data: Data, for key: String, biometricGate: Bool = false) -> Bool {
+        delete(key)
+        var query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: key,
+            kSecValueData as String: data
+        ]
+
+        if biometricGate, let access = SecAccessControlCreateWithFlags(
+            nil,
+            kSecAttrAccessibleWhenUnlockedThisDeviceOnly,
+            [.biometryCurrentSet],
+            nil
+        ) {
+            query[kSecAttrAccessControl as String] = access
+        } else {
+            query[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
+        }
+
+        let status = SecItemAdd(query as CFDictionary, nil)
+        return status == errSecSuccess
+    }
+
+    static func get(_ key: String) -> String? {
+        guard let data = getData(key) else { return nil }
+        return String(data: data, encoding: .utf8)
+    }
+
+    static func getData(_ key: String) -> Data? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: key,
+            kSecReturnData as String: kCFBooleanTrue as Any,
+            kSecMatchLimit as String: kSecMatchLimitOne
+        ]
+        var result: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        guard status == errSecSuccess else { return nil }
+        return result as? Data
+    }
+
+    @discardableResult
+    static func delete(_ key: String) -> Bool {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: key
+        ]
+        let status = SecItemDelete(query as CFDictionary)
+        return status == errSecSuccess || status == errSecItemNotFound
+    }
+
+    static func clearAll() {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service
+        ]
+        SecItemDelete(query as CFDictionary)
+    }
+}

--- a/ios-app/PTSABoard/Services/ThemeManager.swift
+++ b/ios-app/PTSABoard/Services/ThemeManager.swift
@@ -1,0 +1,32 @@
+import SwiftUI
+
+@MainActor
+final class ThemeManager: ObservableObject {
+
+    enum AppearanceChoice: String, CaseIterable, Identifiable {
+        case system, light, dark
+        var id: String { rawValue }
+        var label: String {
+            switch self {
+            case .system: return "System"
+            case .light:  return "Light"
+            case .dark:   return "Dark"
+            }
+        }
+    }
+
+    @AppStorage("ptsa.appearance") private var stored: String = AppearanceChoice.system.rawValue
+
+    var choice: AppearanceChoice {
+        get { AppearanceChoice(rawValue: stored) ?? .system }
+        set { stored = newValue.rawValue; objectWillChange.send() }
+    }
+
+    var preferred: ColorScheme? {
+        switch choice {
+        case .system: return nil
+        case .light:  return .light
+        case .dark:   return .dark
+        }
+    }
+}

--- a/ios-app/PTSABoard/Services/WooCommerceService.swift
+++ b/ios-app/PTSABoard/Services/WooCommerceService.swift
@@ -1,0 +1,147 @@
+import Foundation
+import UIKit
+
+final class WooCommerceService {
+
+    static let shared = WooCommerceService()
+    private init() {}
+
+    private let api = APIClient()
+
+    private var auth: APIClient.AuthMode {
+        guard !AppConfig.wooConsumerKey.hasPrefix("REPLACE_") else {
+            return .none
+        }
+        return .basic(user: AppConfig.wooConsumerKey, pass: AppConfig.wooConsumerSecret)
+    }
+
+    // MARK: - Orders
+
+    func recentOrders(
+        page: Int = 1,
+        perPage: Int = 25,
+        status: String? = nil,
+        search: String? = nil
+    ) async throws -> [WCOrder] {
+        var query: [URLQueryItem] = [
+            URLQueryItem(name: "page", value: "\(page)"),
+            URLQueryItem(name: "per_page", value: "\(perPage)"),
+            URLQueryItem(name: "orderby", value: "date"),
+            URLQueryItem(name: "order", value: "desc")
+        ]
+        if let status, !status.isEmpty, status != "any" {
+            query.append(.init(name: "status", value: status))
+        }
+        if let search, !search.isEmpty {
+            query.append(.init(name: "search", value: search))
+        }
+        let url = AppConfig.wcRestBase.appendingPathComponent("orders")
+        return try await api.request(url, query: query, auth: auth, as: [WCOrder].self)
+    }
+
+    func fetchOrder(_ orderId: Int) async throws -> WCOrder {
+        let url = AppConfig.wcRestBase.appendingPathComponent("orders/\(orderId)")
+        return try await api.request(url, auth: auth, as: WCOrder.self)
+    }
+
+    func updateOrderStatus(_ orderId: Int, to status: String) async throws -> WCOrder {
+        struct Patch: Encodable { let status: String }
+        let body = try JSONEncoder().encode(Patch(status: status))
+        let url = AppConfig.wcRestBase.appendingPathComponent("orders/\(orderId)")
+        return try await api.request(url, method: "PUT", body: body, auth: auth, as: WCOrder.self)
+    }
+
+    func refundOrder(_ orderId: Int, amount: Double, reason: String?) async throws {
+        struct RefundReq: Encodable { let amount: String; let reason: String?; let api_refund: Bool }
+        let body = try JSONEncoder().encode(
+            RefundReq(amount: String(format: "%.2f", amount), reason: reason, api_refund: true)
+        )
+        let url = AppConfig.wcRestBase.appendingPathComponent("orders/\(orderId)/refunds")
+        _ = try await api.raw(url, method: "POST", body: body, auth: auth)
+    }
+
+    func addOrderNote(_ orderId: Int, note: String, customerVisible: Bool) async throws {
+        struct NoteReq: Encodable { let note: String; let customer_note: Bool }
+        let body = try JSONEncoder().encode(NoteReq(note: note, customer_note: customerVisible))
+        let url = AppConfig.wcRestBase.appendingPathComponent("orders/\(orderId)/notes")
+        _ = try await api.raw(url, method: "POST", body: body, auth: auth)
+    }
+
+    // MARK: - Products
+
+    func products(
+        page: Int = 1,
+        perPage: Int = 50,
+        search: String? = nil,
+        type: String? = nil,
+        status: String? = nil
+    ) async throws -> [WCProduct] {
+        var query: [URLQueryItem] = [
+            URLQueryItem(name: "page", value: "\(page)"),
+            URLQueryItem(name: "per_page", value: "\(perPage)"),
+            URLQueryItem(name: "orderby", value: "date"),
+            URLQueryItem(name: "order", value: "desc")
+        ]
+        if let search, !search.isEmpty { query.append(.init(name: "search", value: search)) }
+        if let type, !type.isEmpty, type != "any" { query.append(.init(name: "type", value: type)) }
+        if let status, !status.isEmpty, status != "any" { query.append(.init(name: "status", value: status)) }
+        let url = AppConfig.wcRestBase.appendingPathComponent("products")
+        return try await api.request(url, query: query, auth: auth, as: [WCProduct].self)
+    }
+
+    func updateProduct(_ id: Int, patch: [String: Any]) async throws -> WCProduct {
+        let body = try JSONSerialization.data(withJSONObject: patch)
+        let url = AppConfig.wcRestBase.appendingPathComponent("products/\(id)")
+        return try await api.request(url, method: "PUT", body: body, auth: auth, as: WCProduct.self)
+    }
+
+    func createProduct(_ patch: [String: Any]) async throws -> WCProduct {
+        let body = try JSONSerialization.data(withJSONObject: patch)
+        let url = AppConfig.wcRestBase.appendingPathComponent("products")
+        return try await api.request(url, method: "POST", body: body, auth: auth, as: WCProduct.self)
+    }
+
+    // MARK: - Media (product images)
+
+    /// Upload an image to WordPress media library using app-password Basic auth
+    /// (re-using WC consumer key/secret only works for WC endpoints, so we hit
+    /// the WP REST media endpoint via a custom plugin proxy when available,
+    /// otherwise this requires an application password — see README).
+    func uploadImage(_ image: UIImage, filename: String = "product.jpg") async throws -> WCImage {
+        guard let jpeg = image.jpegData(compressionQuality: 0.85) else {
+            throw APIError.transport(NSError(domain: "Woo", code: -1, userInfo: [NSLocalizedDescriptionKey: "Could not encode image"]))
+        }
+        let url = AppConfig.ptsaRestBase.appendingPathComponent("media")
+        var req = URLRequest(url: url)
+        req.httpMethod = "POST"
+        req.setValue("image/jpeg", forHTTPHeaderField: "Content-Type")
+        req.setValue("attachment; filename=\"\(filename)\"", forHTTPHeaderField: "Content-Disposition")
+        // Plugin endpoint validates the bearer token via Entra ID JWT (see plugin docs in README).
+        if let token = try? await AuthDelegate.shared.token() {
+            req.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        }
+        req.httpBody = jpeg
+
+        let (data, resp) = try await URLSession.shared.data(for: req)
+        guard let http = resp as? HTTPURLResponse, (200..<300).contains(http.statusCode) else {
+            let code = (resp as? HTTPURLResponse)?.statusCode ?? -1
+            throw APIError.http(code, String(data: data.prefix(400), encoding: .utf8))
+        }
+        return try JSONDecoder().decode(WCImage.self, from: data)
+    }
+}
+
+/// Tiny adapter so non-MainActor services can ask for an access token without
+/// keeping a reference to AuthService directly. Set on app launch.
+@MainActor
+final class AuthDelegate {
+    static let shared = AuthDelegate()
+    var tokenProvider: (() async throws -> String)?
+
+    func token() async throws -> String {
+        guard let p = tokenProvider else {
+            throw APIError.notConfigured("AuthDelegate.tokenProvider")
+        }
+        return try await p()
+    }
+}

--- a/ios-app/PTSABoard/Services/WordPressService.swift
+++ b/ios-app/PTSABoard/Services/WordPressService.swift
@@ -1,0 +1,118 @@
+import Foundation
+
+/// WordPress core (users) and custom PTSA Tools endpoints.
+///
+/// For everything that mutates user accounts (password reset, role changes)
+/// we authenticate against a *custom* endpoint we ship from the PTA Tools
+/// WordPress plugin and authorize using the user's Entra ID JWT. See README
+/// for the matching server-side endpoints — until they're deployed these
+/// methods will surface 404s and the UI handles that gracefully.
+final class WordPressService {
+
+    static let shared = WordPressService()
+    private init() {}
+
+    private let api = APIClient()
+
+    private func wpAuth() async throws -> APIClient.AuthMode {
+        let token = try await AuthDelegate.shared.token()
+        return .bearer(token: token)
+    }
+
+    // MARK: - Users (search / list)
+
+    func searchUsers(_ search: String, page: Int = 1, perPage: Int = 25) async throws -> [WPUser] {
+        var query: [URLQueryItem] = [
+            URLQueryItem(name: "page", value: "\(page)"),
+            URLQueryItem(name: "per_page", value: "\(perPage)"),
+            URLQueryItem(name: "context", value: "edit")
+        ]
+        if !search.isEmpty { query.append(.init(name: "search", value: search)) }
+
+        // Custom endpoint is preferred (it can return private fields like email).
+        let url = AppConfig.ptsaRestBase.appendingPathComponent("users")
+        do {
+            return try await api.request(url, query: query, auth: try await wpAuth(), as: [WPUser].self)
+        } catch APIError.http(let code, _) where code == 404 {
+            // Fallback to core wp/v2/users (limited fields, returns only published authors).
+            let core = AppConfig.wpRestBase.appendingPathComponent("users")
+            return try await api.request(core, query: query, auth: try await wpAuth(), as: [WPUser].self)
+        }
+    }
+
+    func fetchUser(_ id: Int) async throws -> WPUser {
+        let url = AppConfig.ptsaRestBase.appendingPathComponent("users/\(id)")
+        return try await api.request(url, auth: try await wpAuth(), as: WPUser.self)
+    }
+
+    func triggerPasswordReset(forEmail email: String) async throws {
+        struct Req: Encodable { let email: String }
+        let body = try JSONEncoder().encode(Req(email: email))
+        let url = AppConfig.ptsaRestBase.appendingPathComponent("users/reset-password")
+        _ = try await api.raw(url, method: "POST", body: body, auth: try await wpAuth())
+    }
+
+    /// Trigger a password reset for the currently signed-in user's own WordPress account.
+    func triggerSelfPasswordReset() async throws {
+        let url = AppConfig.ptsaRestBase.appendingPathComponent("users/reset-password-self")
+        _ = try await api.raw(url, method: "POST", auth: try await wpAuth())
+    }
+
+    func updateUserRoles(_ id: Int, roles: [String]) async throws -> WPUser {
+        struct Req: Encodable { let roles: [String] }
+        let body = try JSONEncoder().encode(Req(roles: roles))
+        let url = AppConfig.ptsaRestBase.appendingPathComponent("users/\(id)")
+        return try await api.request(url, method: "PUT", body: body, auth: try await wpAuth(), as: WPUser.self)
+    }
+
+    // MARK: - Todo / Tech backlog (custom endpoint)
+
+    func listTodos() async throws -> [TodoItem] {
+        let url = AppConfig.ptsaRestBase.appendingPathComponent("todos")
+        return try await api.request(url, auth: try await wpAuth(), as: [TodoItem].self)
+    }
+
+    func createTodo(_ item: TodoItem) async throws -> TodoItem {
+        let url = AppConfig.ptsaRestBase.appendingPathComponent("todos")
+        let body = try JSONEncoder.iso.encode(item)
+        return try await api.request(url, method: "POST", body: body, auth: try await wpAuth(), as: TodoItem.self)
+    }
+
+    func updateTodo(_ item: TodoItem) async throws -> TodoItem {
+        let url = AppConfig.ptsaRestBase.appendingPathComponent("todos/\(item.id)")
+        let body = try JSONEncoder.iso.encode(item)
+        return try await api.request(url, method: "PUT", body: body, auth: try await wpAuth(), as: TodoItem.self)
+    }
+
+    func deleteTodo(_ id: Int) async throws {
+        let url = AppConfig.ptsaRestBase.appendingPathComponent("todos/\(id)")
+        _ = try await api.raw(url, method: "DELETE", auth: try await wpAuth())
+    }
+
+    // MARK: - Auction emails
+
+    /// Server-side endpoint should pull the latest auction items and email
+    /// the resulting bulletin to `to`. We pass an optional subject override.
+    func sendAuctionItemsEmail(to: [String], subject: String?) async throws {
+        struct Req: Encodable { let to: [String]; let subject: String? }
+        let body = try JSONEncoder().encode(Req(to: to, subject: subject))
+        let url = AppConfig.ptsaRestBase.appendingPathComponent("auction/email-items")
+        _ = try await api.raw(url, method: "POST", body: body, auth: try await wpAuth())
+    }
+}
+
+extension JSONEncoder {
+    static let iso: JSONEncoder = {
+        let e = JSONEncoder()
+        e.dateEncodingStrategy = .iso8601
+        return e
+    }()
+}
+
+extension JSONDecoder {
+    static let iso: JSONDecoder = {
+        let d = JSONDecoder()
+        d.dateDecodingStrategy = .iso8601
+        return d
+    }()
+}

--- a/ios-app/PTSABoard/Views/Auth/BiometricLockView.swift
+++ b/ios-app/PTSABoard/Views/Auth/BiometricLockView.swift
@@ -1,0 +1,90 @@
+import SwiftUI
+
+struct BiometricLockView: View {
+    @EnvironmentObject var auth: AuthService
+    @State private var attempting = false
+
+    var body: some View {
+        ZStack {
+            LinearGradient(
+                colors: [Color.accentColor.opacity(0.85), Color.accentColor.opacity(0.45)],
+                startPoint: .topLeading,
+                endPoint: .bottomTrailing
+            )
+            .ignoresSafeArea()
+
+            VStack(spacing: 28) {
+                Spacer()
+
+                VStack(spacing: 12) {
+                    Image(systemName: iconName)
+                        .font(.system(size: 72, weight: .bold))
+                        .foregroundStyle(.white)
+                    Text("PTSA Board")
+                        .font(.system(size: 28, weight: .bold, design: .rounded))
+                        .foregroundStyle(.white)
+                    if let p = auth.profile {
+                        Text(p.displayName)
+                            .foregroundStyle(.white.opacity(0.9))
+                    }
+                }
+
+                Spacer()
+
+                VStack(spacing: 14) {
+                    Button {
+                        Task {
+                            attempting = true
+                            await auth.unlockWithBiometrics()
+                            attempting = false
+                        }
+                    } label: {
+                        HStack(spacing: 12) {
+                            if attempting {
+                                ProgressView().tint(.accentColor)
+                            } else {
+                                Image(systemName: iconName)
+                            }
+                            Text(attempting ? "Authenticating…" : "Unlock with \(label)")
+                                .fontWeight(.semibold)
+                        }
+                        .frame(maxWidth: .infinity, minHeight: 52)
+                        .background(.white)
+                        .foregroundStyle(Color.accentColor)
+                        .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
+                    }
+                    .disabled(attempting)
+
+                    Button("Use a different account") {
+                        Task { await auth.signOut() }
+                    }
+                    .foregroundStyle(.white.opacity(0.9))
+                }
+                .padding(.horizontal, 24)
+                .padding(.bottom, 50)
+            }
+        }
+        .task {
+            // Auto-prompt on entry.
+            await auth.unlockWithBiometrics()
+        }
+    }
+
+    private var iconName: String {
+        switch BiometricService.available {
+        case .faceID:  return "faceid"
+        case .touchID: return "touchid"
+        case .opticID: return "opticid"
+        case .none:    return "lock.fill"
+        }
+    }
+
+    private var label: String {
+        switch BiometricService.available {
+        case .faceID:  return "Face ID"
+        case .touchID: return "Touch ID"
+        case .opticID: return "Optic ID"
+        case .none:    return "passcode"
+        }
+    }
+}

--- a/ios-app/PTSABoard/Views/Auth/LoginView.swift
+++ b/ios-app/PTSABoard/Views/Auth/LoginView.swift
@@ -1,0 +1,85 @@
+import SwiftUI
+
+struct LoginView: View {
+    @EnvironmentObject var auth: AuthService
+    @State private var signingIn = false
+
+    var body: some View {
+        ZStack {
+            LinearGradient(
+                colors: [Color.accentColor.opacity(0.85), Color.accentColor.opacity(0.45)],
+                startPoint: .topLeading,
+                endPoint: .bottomTrailing
+            )
+            .ignoresSafeArea()
+
+            VStack(spacing: 28) {
+                Spacer()
+
+                VStack(spacing: 8) {
+                    Image(systemName: "graduationcap.fill")
+                        .font(.system(size: 64, weight: .bold))
+                        .foregroundStyle(.white)
+                    Text("Wilder PTSA")
+                        .font(.system(size: 34, weight: .bold, design: .rounded))
+                        .foregroundStyle(.white)
+                    Text("Board Console")
+                        .font(.title3)
+                        .foregroundStyle(.white.opacity(0.85))
+                }
+
+                Spacer()
+
+                VStack(spacing: 16) {
+                    Button {
+                        Task {
+                            signingIn = true
+                            if let vc = TopController.current() {
+                                await auth.signIn(presenter: vc)
+                            }
+                            signingIn = false
+                        }
+                    } label: {
+                        HStack(spacing: 12) {
+                            if signingIn {
+                                ProgressView()
+                                    .tint(.accentColor)
+                            } else {
+                                Image(systemName: "lock.shield.fill")
+                                    .font(.title3)
+                            }
+                            Text(signingIn ? "Signing in…" : "Sign in with Microsoft")
+                                .fontWeight(.semibold)
+                        }
+                        .frame(maxWidth: .infinity, minHeight: 52)
+                        .background(.white)
+                        .foregroundStyle(Color.accentColor)
+                        .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
+                    }
+                    .disabled(signingIn)
+
+                    Text("Use your **@\(AppConfig.allowedEmailDomain)** account")
+                        .font(.footnote)
+                        .foregroundStyle(.white.opacity(0.85))
+
+                    if let err = auth.lastError {
+                        Text(err)
+                            .font(.caption)
+                            .multilineTextAlignment(.center)
+                            .padding(10)
+                            .background(.red.opacity(0.85))
+                            .foregroundStyle(.white)
+                            .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+                            .padding(.horizontal, 8)
+                    }
+                }
+                .padding(.horizontal, 24)
+                .padding(.bottom, 40)
+            }
+        }
+    }
+}
+
+#Preview {
+    LoginView().environmentObject(AuthService())
+}

--- a/ios-app/PTSABoard/Views/Calendar/CalendarView.swift
+++ b/ios-app/PTSABoard/Views/Calendar/CalendarView.swift
@@ -1,0 +1,122 @@
+import SwiftUI
+
+struct CalendarView: View {
+    @EnvironmentObject var auth: AuthService
+    @State private var selectedDate = Date()
+    @State private var events: [GraphEvent] = []
+    @State private var loading = false
+    @State private var error: String?
+    @State private var showCreate = false
+
+    var body: some View {
+        VStack(spacing: 0) {
+            DatePicker(
+                "Date",
+                selection: $selectedDate,
+                displayedComponents: .date
+            )
+            .datePickerStyle(.graphical)
+            .padding(.horizontal)
+            .padding(.bottom, 4)
+            .onChange(of: selectedDate) { _, _ in Task { await load() } }
+
+            Divider()
+
+            Group {
+                if eventsToday.isEmpty && !loading {
+                    EmptyStateView(
+                        systemImage: "calendar",
+                        title: "No events",
+                        message: error ?? "Nothing scheduled for this day."
+                    )
+                } else {
+                    List {
+                        ForEach(eventsToday) { ev in
+                            EventRow(event: ev)
+                        }
+                    }
+                    .listStyle(.plain)
+                }
+            }
+        }
+        .navigationTitle("Calendar")
+        .toolbar {
+            ToolbarItem(placement: .topBarLeading) {
+                Button { selectedDate = Date() } label: { Text("Today") }
+            }
+            ToolbarItem(placement: .topBarTrailing) {
+                Button { showCreate = true } label: { Image(systemName: "plus.circle.fill") }
+            }
+        }
+        .refreshable { await load() }
+        .task { await load() }
+        .sheet(isPresented: $showCreate) {
+            NavigationStack {
+                EventEditView(initialDate: selectedDate) { newEv in
+                    events.append(newEv)
+                }
+            }
+        }
+        .overlay(alignment: .top) {
+            if let error {
+                ErrorBanner(message: error) { self.error = nil }.padding(.top, 4)
+            }
+        }
+        .overlay {
+            if loading && events.isEmpty { ProgressView().controlSize(.large) }
+        }
+    }
+
+    private var eventsToday: [GraphEvent] {
+        let cal = Calendar.current
+        return events.filter { ev in
+            guard let s = ev.startDate else { return false }
+            return cal.isDate(s, inSameDayAs: selectedDate)
+        }
+        .sorted { ($0.startDate ?? .distantPast) < ($1.startDate ?? .distantPast) }
+    }
+
+    @MainActor
+    private func load() async {
+        loading = true; defer { loading = false }
+        do {
+            let cal = Calendar.current
+            let start = cal.startOfDay(for: selectedDate)
+            let end = cal.date(byAdding: .day, value: 14, to: start) ?? start
+            let token = try await auth.graphAccessToken()
+            events = try await GraphService.shared.sharedCalendarEvents(accessToken: token, from: start, to: end)
+            error = nil
+        } catch {
+            self.error = error.localizedDescription
+        }
+    }
+}
+
+private struct EventRow: View {
+    let event: GraphEvent
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack {
+                Text(event.subject ?? "(No title)")
+                    .font(.headline)
+                Spacer()
+                if let s = event.startDate {
+                    Text(s.formatted(date: .omitted, time: .shortened))
+                        .font(.subheadline)
+                        .monospacedDigit()
+                        .foregroundStyle(.secondary)
+                }
+            }
+            if let loc = event.location?.displayName, !loc.isEmpty {
+                Label(loc, systemImage: "mappin.and.ellipse")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            if let preview = event.bodyPreview?.trimmingCharacters(in: .whitespacesAndNewlines), !preview.isEmpty {
+                Text(preview).font(.caption).foregroundStyle(.secondary).lineLimit(2)
+            }
+        }
+        .padding(.vertical, 4)
+    }
+}

--- a/ios-app/PTSABoard/Views/Calendar/EventEditView.swift
+++ b/ios-app/PTSABoard/Views/Calendar/EventEditView.swift
@@ -1,0 +1,81 @@
+import SwiftUI
+
+struct EventEditView: View {
+    @EnvironmentObject var auth: AuthService
+    @Environment(\.dismiss) private var dismiss
+
+    @State var initialDate: Date
+    var onCreated: (GraphEvent) -> Void
+
+    @State private var subject = ""
+    @State private var location = ""
+    @State private var notes = ""
+    @State private var start = Date()
+    @State private var end = Date().addingTimeInterval(3600)
+    @State private var allDay = false
+    @State private var saving = false
+    @State private var error: String?
+
+    init(initialDate: Date, onCreated: @escaping (GraphEvent) -> Void) {
+        self.initialDate = initialDate
+        self.onCreated = onCreated
+        let cal = Calendar.current
+        let s = cal.date(bySettingHour: 9, minute: 0, second: 0, of: initialDate) ?? initialDate
+        let e = cal.date(byAdding: .hour, value: 1, to: s) ?? initialDate
+        _start = State(initialValue: s)
+        _end = State(initialValue: e)
+    }
+
+    var body: some View {
+        Form {
+            Section("Event") {
+                TextField("Title", text: $subject)
+                TextField("Location", text: $location)
+                Toggle("All day", isOn: $allDay)
+                DatePicker("Starts", selection: $start, displayedComponents: allDay ? [.date] : [.date, .hourAndMinute])
+                DatePicker("Ends", selection: $end, displayedComponents: allDay ? [.date] : [.date, .hourAndMinute])
+            }
+            Section("Notes") {
+                TextField("Optional", text: $notes, axis: .vertical).lineLimit(3...10)
+            }
+        }
+        .navigationTitle("New Event")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .cancellationAction) { Button("Cancel") { dismiss() } }
+            ToolbarItem(placement: .confirmationAction) {
+                Button("Add") { Task { await save() } }.disabled(subject.isEmpty || saving)
+            }
+        }
+        .overlay { if saving { ProgressView().controlSize(.large) } }
+        .overlay(alignment: .top) {
+            if let error {
+                ErrorBanner(message: error) { self.error = nil }.padding(.top, 4)
+            }
+        }
+    }
+
+    @MainActor
+    private func save() async {
+        saving = true; defer { saving = false }
+        do {
+            let html = """
+            <html><body>\(notes.replacingOccurrences(of: "\n", with: "<br>"))</body></html>
+            """
+            let token = try await auth.graphAccessToken()
+            let created = try await GraphService.shared.createSharedEvent(
+                accessToken: token,
+                subject: subject,
+                bodyHTML: html,
+                start: start,
+                end: end,
+                isAllDay: allDay,
+                location: location.isEmpty ? nil : location
+            )
+            onCreated(created)
+            dismiss()
+        } catch {
+            self.error = error.localizedDescription
+        }
+    }
+}

--- a/ios-app/PTSABoard/Views/Common/AvatarView.swift
+++ b/ios-app/PTSABoard/Views/Common/AvatarView.swift
@@ -1,0 +1,24 @@
+import SwiftUI
+
+struct AvatarView: View {
+    let profile: UserProfile?
+    var size: CGFloat = 32
+
+    var body: some View {
+        ZStack {
+            Circle()
+                .fill(LinearGradient(
+                    colors: [.accentColor.opacity(0.9), .accentColor.opacity(0.6)],
+                    startPoint: .topLeading, endPoint: .bottomTrailing
+                ))
+            Text(profile?.initials ?? "?")
+                .font(.system(size: size * 0.42, weight: .bold, design: .rounded))
+                .foregroundStyle(.white)
+        }
+        .frame(width: size, height: size)
+        .overlay(
+            Circle().stroke(.white.opacity(0.5), lineWidth: 1.5)
+        )
+        .shadow(color: .black.opacity(0.1), radius: 2, x: 0, y: 1)
+    }
+}

--- a/ios-app/PTSABoard/Views/Common/Components.swift
+++ b/ios-app/PTSABoard/Views/Common/Components.swift
@@ -1,0 +1,140 @@
+import SwiftUI
+
+// MARK: - Section card
+
+struct Card<Content: View>: View {
+    var padding: CGFloat = 16
+    @ViewBuilder var content: () -> Content
+
+    var body: some View {
+        content()
+            .padding(padding)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(
+                RoundedRectangle(cornerRadius: 16, style: .continuous)
+                    .fill(Color(.secondarySystemGroupedBackground))
+                    .shadow(color: .black.opacity(0.04), radius: 6, x: 0, y: 2)
+            )
+    }
+}
+
+// MARK: - Status pill
+
+struct StatusPill: View {
+    let text: String
+    var color: Color = .gray
+
+    var body: some View {
+        Text(text)
+            .font(.caption.weight(.semibold))
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+            .background(color.opacity(0.15))
+            .foregroundStyle(color)
+            .clipShape(Capsule())
+    }
+}
+
+extension WCOrder {
+    var statusColor: Color {
+        switch status {
+        case "completed": return .green
+        case "processing": return .blue
+        case "on-hold":    return .orange
+        case "pending":    return .yellow
+        case "cancelled":  return .gray
+        case "refunded":   return .purple
+        case "failed":     return .red
+        default:           return .secondary
+        }
+    }
+}
+
+// MARK: - Empty state
+
+struct EmptyStateView: View {
+    let systemImage: String
+    let title: String
+    let message: String
+
+    var body: some View {
+        VStack(spacing: 14) {
+            Image(systemName: systemImage)
+                .font(.system(size: 48))
+                .foregroundStyle(.secondary)
+            Text(title)
+                .font(.headline)
+            Text(message)
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+        }
+        .padding(40)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}
+
+// MARK: - Inline error banner
+
+struct ErrorBanner: View {
+    let message: String
+    var onDismiss: (() -> Void)? = nil
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 10) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .foregroundStyle(.white)
+            Text(message)
+                .font(.footnote)
+                .foregroundStyle(.white)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            if let onDismiss {
+                Button(action: onDismiss) {
+                    Image(systemName: "xmark.circle.fill").foregroundStyle(.white.opacity(0.8))
+                }
+            }
+        }
+        .padding(12)
+        .background(Color.red.opacity(0.9))
+        .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+        .padding(.horizontal)
+    }
+}
+
+// MARK: - Async image with placeholder
+
+struct ThumbnailImage: View {
+    let url: URL?
+    var size: CGFloat = 56
+    var corner: CGFloat = 10
+
+    var body: some View {
+        AsyncImage(url: url) { phase in
+            switch phase {
+            case .success(let image):
+                image.resizable().scaledToFill()
+            case .failure:
+                placeholder
+            case .empty:
+                placeholder.overlay(ProgressView().scaleEffect(0.7))
+            @unknown default:
+                placeholder
+            }
+        }
+        .frame(width: size, height: size)
+        .clipShape(RoundedRectangle(cornerRadius: corner, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: corner, style: .continuous)
+                .stroke(Color.black.opacity(0.06), lineWidth: 0.5)
+        )
+    }
+
+    private var placeholder: some View {
+        ZStack {
+            RoundedRectangle(cornerRadius: corner, style: .continuous)
+                .fill(Color(.tertiarySystemFill))
+            Image(systemName: "photo")
+                .foregroundStyle(.secondary)
+        }
+    }
+}

--- a/ios-app/PTSABoard/Views/MainTabView.swift
+++ b/ios-app/PTSABoard/Views/MainTabView.swift
@@ -1,0 +1,66 @@
+import SwiftUI
+
+struct MainTabView: View {
+    @EnvironmentObject var auth: AuthService
+    @State private var selection: Tab = .orders
+    @State private var showSettings = false
+
+    enum Tab: Hashable {
+        case orders, products, calendar, users, todo
+    }
+
+    var body: some View {
+        TabView(selection: $selection) {
+            NavigationStack {
+                OrdersView()
+                    .toolbar { avatarToolbar }
+            }
+            .tabItem { Label("Orders", systemImage: "bag.fill") }
+            .tag(Tab.orders)
+
+            NavigationStack {
+                ProductsView()
+                    .toolbar { avatarToolbar }
+            }
+            .tabItem { Label("Products", systemImage: "cube.box.fill") }
+            .tag(Tab.products)
+
+            NavigationStack {
+                CalendarView()
+                    .toolbar { avatarToolbar }
+            }
+            .tabItem { Label("Calendar", systemImage: "calendar") }
+            .tag(Tab.calendar)
+
+            NavigationStack {
+                UsersView()
+                    .toolbar { avatarToolbar }
+            }
+            .tabItem { Label("Users", systemImage: "person.2.fill") }
+            .tag(Tab.users)
+
+            NavigationStack {
+                TodoView()
+                    .toolbar { avatarToolbar }
+            }
+            .tabItem { Label("Backlog", systemImage: "checklist") }
+            .tag(Tab.todo)
+        }
+        .sheet(isPresented: $showSettings) {
+            SettingsView()
+                .environmentObject(auth)
+        }
+    }
+
+    @ToolbarContentBuilder
+    private var avatarToolbar: some ToolbarContent {
+        ToolbarItem(placement: .topBarTrailing) {
+            Button {
+                showSettings = true
+            } label: {
+                AvatarView(profile: auth.profile)
+            }
+            .accessibilityLabel("Account & settings")
+        }
+    }
+}

--- a/ios-app/PTSABoard/Views/Orders/OrderDetailView.swift
+++ b/ios-app/PTSABoard/Views/Orders/OrderDetailView.swift
@@ -1,0 +1,305 @@
+import SwiftUI
+
+struct OrderDetailView: View {
+    @State var order: WCOrder
+    @State private var error: String?
+    @State private var processing = false
+    @State private var showRefund = false
+    @State private var refundAmount: String = ""
+    @State private var refundReason: String = ""
+    @State private var showNote = false
+    @State private var noteText = ""
+    @State private var customerVisible = false
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 16) {
+                summary
+                customerCard
+                itemsCard
+                actionsCard
+                if order.customer_note?.isEmpty == false {
+                    Card { Text(order.customer_note!) }
+                }
+            }
+            .padding()
+        }
+        .navigationTitle("Order #\(order.number)")
+        .navigationBarTitleDisplayMode(.inline)
+        .overlay(alignment: .top) {
+            if let error {
+                ErrorBanner(message: error) { self.error = nil }
+                    .padding(.top, 8)
+            }
+        }
+        .sheet(isPresented: $showRefund) {
+            refundSheet.presentationDetents([.medium])
+        }
+        .sheet(isPresented: $showNote) {
+            noteSheet.presentationDetents([.medium])
+        }
+    }
+
+    // MARK: - Cards
+
+    private var summary: some View {
+        Card {
+            HStack(alignment: .top) {
+                VStack(alignment: .leading, spacing: 6) {
+                    StatusPill(text: order.displayStatus, color: order.statusColor)
+                    Text(formatTotal(order))
+                        .font(.system(size: 32, weight: .bold, design: .rounded))
+                        .monospacedDigit()
+                    if let pm = order.payment_method_title, !pm.isEmpty {
+                        Label(pm, systemImage: "creditcard.fill")
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                Spacer()
+            }
+        }
+    }
+
+    private var customerCard: some View {
+        Card {
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Customer").font(.caption).foregroundStyle(.secondary)
+                Text(order.customerName).font(.headline)
+                if let e = order.customerEmail, !e.isEmpty {
+                    Link(destination: URL(string: "mailto:\(e)")!) {
+                        Label(e, systemImage: "envelope")
+                    }
+                    .font(.subheadline)
+                }
+                if let p = order.billing?.phone, !p.isEmpty {
+                    Link(destination: URL(string: "tel:\(p.filter { !$0.isWhitespace })")!) {
+                        Label(p, systemImage: "phone")
+                    }
+                    .font(.subheadline)
+                }
+            }
+        }
+    }
+
+    private var itemsCard: some View {
+        Card {
+            VStack(alignment: .leading, spacing: 10) {
+                Text("Items").font(.caption).foregroundStyle(.secondary)
+                ForEach(order.line_items) { item in
+                    HStack(alignment: .top) {
+                        Text("\(item.quantity)×")
+                            .font(.subheadline.weight(.semibold))
+                            .frame(width: 32, alignment: .leading)
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(item.name).font(.subheadline)
+                            if let sku = item.sku, !sku.isEmpty {
+                                Text(sku).font(.caption).foregroundStyle(.secondary)
+                            }
+                        }
+                        Spacer()
+                        Text(item.total)
+                            .font(.subheadline).monospacedDigit()
+                        Menu {
+                            // Always-available row actions
+                            Button {
+                                if let mail = order.customerEmail {
+                                    let subject = "Your order for \(item.name)".addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? ""
+                                    UIApplication.shared.open(URL(string: "mailto:\(mail)?subject=\(subject)")!)
+                                }
+                            } label: { Label("Email customer about this item", systemImage: "envelope") }
+
+                            // Context-specific (heuristic on item name) — auction items get a "pickup info" template
+                            if item.name.localizedCaseInsensitiveContains("auction") {
+                                Button {
+                                    sendAuctionPickup(for: item)
+                                } label: { Label("Send auction pickup info", systemImage: "tag.fill") }
+                            }
+                            if item.name.localizedCaseInsensitiveContains("ticket") {
+                                Button {
+                                    if let mail = order.customerEmail {
+                                        let subj = "Your tickets for \(item.name)".addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? ""
+                                        UIApplication.shared.open(URL(string: "mailto:\(mail)?subject=\(subj)")!)
+                                    }
+                                } label: { Label("Resend tickets / event info", systemImage: "ticket.fill") }
+                            }
+                            if item.name.localizedCaseInsensitiveContains("donation") {
+                                Button {
+                                    if let mail = order.customerEmail {
+                                        let subj = "Thank you for your donation".addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? ""
+                                        UIApplication.shared.open(URL(string: "mailto:\(mail)?subject=\(subj)")!)
+                                    }
+                                } label: { Label("Send tax-receipt", systemImage: "doc.text.fill") }
+                            }
+                        } label: {
+                            Image(systemName: "ellipsis.circle")
+                                .foregroundStyle(Color.accentColor)
+                        }
+                    }
+                    Divider()
+                }
+            }
+        }
+    }
+
+    private func sendAuctionPickup(for item: WCLineItem) {
+        guard let mail = order.customerEmail else { return }
+        let subj = "Your auction win: \(item.name)"
+            .addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? ""
+        let body = """
+        Hi \(order.customerName),
+
+        Congratulations on winning "\(item.name)" in the Wilder PTSA Auction! Here's how to pick it up:
+
+        — When: please see the auction info page.
+        — Where: Wilder PTSA office.
+        — Need help? Just reply to this email.
+
+        Thank you for supporting Wilder!
+        """
+            .addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? ""
+        UIApplication.shared.open(URL(string: "mailto:\(mail)?subject=\(subj)&body=\(body)")!)
+    }
+
+    private var actionsCard: some View {
+        Card {
+            VStack(alignment: .leading, spacing: 10) {
+                Text("Actions").font(.caption).foregroundStyle(.secondary)
+                actionRow(
+                    "Mark as Completed", "checkmark.seal.fill", .green,
+                    enabled: order.status != "completed"
+                ) { Task { await update(to: "completed") } }
+                actionRow(
+                    "Mark as Processing", "shippingbox.fill", .blue,
+                    enabled: order.status != "processing"
+                ) { Task { await update(to: "processing") } }
+                actionRow(
+                    "Put On Hold", "pause.circle.fill", .orange,
+                    enabled: order.status != "on-hold"
+                ) { Task { await update(to: "on-hold") } }
+                actionRow(
+                    "Cancel Order", "xmark.octagon.fill", .red,
+                    enabled: order.status != "cancelled"
+                ) { Task { await update(to: "cancelled") } }
+                Divider()
+                actionRow("Refund…", "arrow.uturn.backward.circle.fill", .purple) {
+                    refundAmount = String(format: "%.2f", order.totalAmount)
+                    showRefund = true
+                }
+                actionRow("Add Note…", "note.text.badge.plus", .indigo) {
+                    showNote = true
+                }
+                actionRow("Email Customer…", "envelope.badge.fill", .teal) {
+                    if let mail = order.customerEmail {
+                        UIApplication.shared.open(URL(string: "mailto:\(mail)?subject=Your%20PTSA%20Order%20%23\(order.number)")!)
+                    }
+                }
+            }
+        }
+        .overlay(alignment: .topTrailing) {
+            if processing { ProgressView().padding(10) }
+        }
+    }
+
+    private func actionRow(_ title: String, _ icon: String, _ color: Color, enabled: Bool = true, _ run: @escaping () -> Void) -> some View {
+        Button(action: run) {
+            HStack {
+                Image(systemName: icon).foregroundStyle(color).frame(width: 24)
+                Text(title).foregroundStyle(enabled ? .primary : .secondary)
+                Spacer()
+                Image(systemName: "chevron.right").foregroundStyle(.tertiary).font(.footnote)
+            }
+            .padding(.vertical, 6)
+        }
+        .disabled(!enabled || processing)
+    }
+
+    // MARK: - Sheets
+
+    private var refundSheet: some View {
+        NavigationStack {
+            Form {
+                Section("Amount") {
+                    HStack {
+                        Text(order.currency)
+                        TextField("0.00", text: $refundAmount)
+                            .keyboardType(.decimalPad)
+                    }
+                }
+                Section("Reason") {
+                    TextField("Optional", text: $refundReason, axis: .vertical)
+                }
+            }
+            .navigationTitle("Issue refund")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { showRefund = false }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Refund") {
+                        Task {
+                            showRefund = false
+                            await runRefund()
+                        }
+                    }.disabled(Double(refundAmount) == nil)
+                }
+            }
+        }
+    }
+
+    private var noteSheet: some View {
+        NavigationStack {
+            Form {
+                TextField("Note", text: $noteText, axis: .vertical).lineLimit(3...10)
+                Toggle("Send to customer", isOn: $customerVisible)
+            }
+            .navigationTitle("Add note")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) { Button("Cancel") { showNote = false } }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Add") {
+                        Task { showNote = false; await addNote() }
+                    }.disabled(noteText.isEmpty)
+                }
+            }
+        }
+    }
+
+    // MARK: - Actions
+
+    @MainActor
+    private func update(to status: String) async {
+        processing = true; defer { processing = false }
+        do {
+            order = try await WooCommerceService.shared.updateOrderStatus(order.id, to: status)
+        } catch { self.error = error.localizedDescription }
+    }
+
+    @MainActor
+    private func runRefund() async {
+        processing = true; defer { processing = false }
+        guard let amount = Double(refundAmount) else { return }
+        do {
+            try await WooCommerceService.shared.refundOrder(order.id, amount: amount, reason: refundReason.isEmpty ? nil : refundReason)
+            order = try await WooCommerceService.shared.fetchOrder(order.id)
+        } catch { self.error = error.localizedDescription }
+    }
+
+    @MainActor
+    private func addNote() async {
+        processing = true; defer { processing = false }
+        do {
+            try await WooCommerceService.shared.addOrderNote(order.id, note: noteText, customerVisible: customerVisible)
+            noteText = ""
+        } catch { self.error = error.localizedDescription }
+    }
+
+    private func formatTotal(_ o: WCOrder) -> String {
+        let fmt = NumberFormatter()
+        fmt.numberStyle = .currency
+        fmt.currencyCode = o.currency
+        return fmt.string(from: NSNumber(value: o.totalAmount)) ?? "\(o.currency) \(o.total)"
+    }
+}

--- a/ios-app/PTSABoard/Views/Orders/OrdersView.swift
+++ b/ios-app/PTSABoard/Views/Orders/OrdersView.swift
@@ -1,0 +1,181 @@
+import SwiftUI
+
+struct OrdersView: View {
+    @State private var orders: [WCOrder] = []
+    @State private var loading = false
+    @State private var error: String?
+    @State private var statusFilter = "any"
+    @State private var search = ""
+
+    private let statuses = [
+        ("any", "All"),
+        ("processing", "Processing"),
+        ("on-hold", "On Hold"),
+        ("pending", "Pending"),
+        ("completed", "Completed"),
+        ("cancelled", "Cancelled"),
+        ("refunded", "Refunded")
+    ]
+
+    var body: some View {
+        Group {
+            if orders.isEmpty && !loading {
+                EmptyStateView(
+                    systemImage: "bag",
+                    title: "No orders",
+                    message: error ?? "Pull to refresh, or change the filter above."
+                )
+            } else {
+                List {
+                    ForEach(orders) { order in
+                        NavigationLink(value: order) {
+                            OrderRow(order: order)
+                        }
+                        .swipeActions(edge: .leading) {
+                            Button {
+                                Task { await update(order, to: "completed") }
+                            } label: { Label("Complete", systemImage: "checkmark.circle.fill") }
+                                .tint(.green)
+                        }
+                        .swipeActions(edge: .trailing) {
+                            Button {
+                                Task { await update(order, to: "on-hold") }
+                            } label: { Label("Hold", systemImage: "pause.circle.fill") }
+                                .tint(.orange)
+                            Button(role: .destructive) {
+                                Task { await update(order, to: "cancelled") }
+                            } label: { Label("Cancel", systemImage: "xmark.circle.fill") }
+                        }
+                    }
+                }
+                .listStyle(.insetGrouped)
+            }
+        }
+        .navigationTitle("Orders")
+        .searchable(text: $search, prompt: "Search orders")
+        .toolbar {
+            ToolbarItem(placement: .topBarLeading) {
+                Menu {
+                    Picker("Status", selection: $statusFilter) {
+                        ForEach(statuses, id: \.0) { Text($0.1).tag($0.0) }
+                    }
+                } label: {
+                    Image(systemName: "line.3.horizontal.decrease.circle")
+                }
+            }
+        }
+        .navigationDestination(for: WCOrder.self) { OrderDetailView(order: $0) }
+        .refreshable { await load() }
+        .task(id: statusFilter) { await load() }
+        .onChange(of: search) {
+            Task {
+                try? await Task.sleep(nanoseconds: 350_000_000)
+                if !Task.isCancelled { await load() }
+            }
+        }
+        .overlay(alignment: .top) {
+            if let error {
+                ErrorBanner(message: error) { self.error = nil }
+                    .padding(.top, 4)
+            }
+        }
+        .overlay {
+            if loading && orders.isEmpty {
+                ProgressView().controlSize(.large)
+            }
+        }
+    }
+
+    @MainActor
+    private func load() async {
+        loading = true; defer { loading = false }
+        do {
+            orders = try await WooCommerceService.shared.recentOrders(
+                status: statusFilter == "any" ? nil : statusFilter,
+                search: search.isEmpty ? nil : search
+            )
+            error = nil
+        } catch {
+            self.error = error.localizedDescription
+        }
+    }
+
+    @MainActor
+    private func update(_ order: WCOrder, to status: String) async {
+        do {
+            let updated = try await WooCommerceService.shared.updateOrderStatus(order.id, to: status)
+            if let idx = orders.firstIndex(where: { $0.id == order.id }) {
+                orders[idx] = updated
+            }
+        } catch {
+            self.error = error.localizedDescription
+        }
+    }
+}
+
+private struct OrderRow: View {
+    let order: WCOrder
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 12) {
+            ZStack {
+                Circle().fill(order.statusColor.opacity(0.15))
+                Image(systemName: "bag.fill").foregroundStyle(order.statusColor)
+            }
+            .frame(width: 38, height: 38)
+
+            VStack(alignment: .leading, spacing: 4) {
+                HStack {
+                    Text("#\(order.number)")
+                        .font(.headline)
+                    Spacer()
+                    Text(formatTotal(order))
+                        .font(.headline)
+                        .monospacedDigit()
+                }
+                Text(order.customerName)
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                HStack(spacing: 8) {
+                    StatusPill(text: order.displayStatus, color: order.statusColor)
+                    if order.line_items.count > 0 {
+                        Text("\(order.line_items.reduce(0) { $0 + $1.quantity }) items")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                    Spacer()
+                    if let date = order.date_created {
+                        Text(prettyDate(date))
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            }
+        }
+        .padding(.vertical, 4)
+    }
+
+    private func formatTotal(_ o: WCOrder) -> String {
+        let fmt = NumberFormatter()
+        fmt.numberStyle = .currency
+        fmt.currencyCode = o.currency
+        return fmt.string(from: NSNumber(value: o.totalAmount)) ?? "\(o.currency) \(o.total)"
+    }
+
+    private func prettyDate(_ raw: String) -> String {
+        let iso = ISO8601DateFormatter()
+        iso.formatOptions = [.withInternetDateTime]
+        if let d = iso.date(from: raw + (raw.hasSuffix("Z") ? "" : "Z")) {
+            return d.formatted(.relative(presentation: .named))
+        }
+        // WP returns local datetime without TZ; try plain
+        let fb = DateFormatter()
+        fb.dateFormat = "yyyy-MM-dd'T'HH:mm:ss"
+        fb.locale = Locale(identifier: "en_US_POSIX")
+        if let d = fb.date(from: raw) {
+            return d.formatted(.relative(presentation: .named))
+        }
+        return raw
+    }
+}

--- a/ios-app/PTSABoard/Views/Products/ProductEditView.swift
+++ b/ios-app/PTSABoard/Views/Products/ProductEditView.swift
@@ -1,0 +1,331 @@
+import SwiftUI
+import PhotosUI
+
+struct ProductEditView: View {
+    @State var product: WCProduct
+    var isCreating: Bool = false
+
+    @State private var saving = false
+    @State private var error: String?
+    @State private var showAdvanced = false
+    @State private var photoPickerItem: PhotosPickerItem?
+    @State private var showCameraPicker = false
+
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        Form {
+            // Image section
+            Section {
+                HStack(spacing: 12) {
+                    ThumbnailImage(url: product.primaryImageURL, size: 84, corner: 14)
+                    VStack(alignment: .leading, spacing: 8) {
+                        PhotosPicker(
+                            selection: $photoPickerItem, matching: .images
+                        ) {
+                            Label("Choose from Library", systemImage: "photo.on.rectangle")
+                        }
+                        .buttonStyle(.bordered)
+
+                        Button {
+                            showCameraPicker = true
+                        } label: {
+                            Label("Take Photo", systemImage: "camera.fill")
+                        }
+                        .buttonStyle(.bordered)
+                    }
+                    Spacer()
+                }
+            } header: { Text("Image") }
+
+            // Always-visible basics
+            Section {
+                TextField("Name", text: $product.name)
+                TextField("Short description", text: Binding(
+                    get: { product.short_description ?? "" },
+                    set: { product.short_description = $0 }
+                ), axis: .vertical).lineLimit(2...5)
+
+                TextField("Description", text: Binding(
+                    get: { product.description ?? "" },
+                    set: { product.description = $0 }
+                ), axis: .vertical).lineLimit(3...10)
+
+                Picker("Type", selection: $product.type) {
+                    Text("Simple").tag("simple")
+                    Text("Variable").tag("variable")
+                    Text("Grouped").tag("grouped")
+                    Text("External").tag("external")
+                    Text("Auction").tag("auction")
+                    Text("Donation").tag("donation")
+                }
+            } header: { Text("Basics") }
+
+            // Price (hidden for grouped / external; donation gets a different label)
+            if pricingVisible {
+                Section {
+                    HStack {
+                        Text("$")
+                        TextField("0.00", text: Binding(
+                            get: { product.regular_price ?? product.price ?? "" },
+                            set: { product.regular_price = $0; product.price = $0 }
+                        ))
+                        .keyboardType(.decimalPad)
+                    }
+                    HStack {
+                        Text("Sale $")
+                        TextField("Optional", text: Binding(
+                            get: { product.sale_price ?? "" },
+                            set: { product.sale_price = $0 }
+                        ))
+                        .keyboardType(.decimalPad)
+                    }
+                } header: { Text(product.type == "donation" ? "Suggested Amount" : "Price") }
+            }
+
+            Section {
+                Picker("Status", selection: $product.status) {
+                    Text("Published").tag("publish")
+                    Text("Draft").tag("draft")
+                    Text("Pending").tag("pending")
+                    Text("Private").tag("private")
+                }
+                Toggle("Featured", isOn: Binding(
+                    get: { product.featured ?? false },
+                    set: { product.featured = $0 }
+                ))
+            } header: { Text("Visibility") }
+
+            // Inventory (hide for external, grouped, donation, auction)
+            if inventoryVisible {
+                Section {
+                    TextField("SKU", text: Binding(
+                        get: { product.sku ?? "" },
+                        set: { product.sku = $0 }
+                    ))
+                    Toggle("Manage stock", isOn: Binding(
+                        get: { product.manage_stock ?? false },
+                        set: { product.manage_stock = $0 }
+                    ))
+                    if product.manage_stock == true {
+                        HStack {
+                            Text("Quantity")
+                            Spacer()
+                            TextField("0", value: Binding(
+                                get: { product.stock_quantity ?? 0 },
+                                set: { product.stock_quantity = $0 }
+                            ), format: .number)
+                                .keyboardType(.numberPad)
+                                .multilineTextAlignment(.trailing)
+                        }
+                    }
+                } header: { Text("Inventory") }
+            }
+
+            // Advanced (collapsed by default, customized per type)
+            Section {
+                DisclosureGroup(isExpanded: $showAdvanced) {
+                    if shippingVisible {
+                        TextField("Weight (lb)", text: Binding(
+                            get: { product.weight ?? "" },
+                            set: { product.weight = $0 }
+                        )).keyboardType(.decimalPad)
+                        TextField("Length", text: Binding(
+                            get: { product.dimensions?.length ?? "" },
+                            set: { val in
+                                var d = product.dimensions ?? WCDimensions()
+                                d.length = val
+                                product.dimensions = d
+                            }
+                        )).keyboardType(.decimalPad)
+                        TextField("Width", text: Binding(
+                            get: { product.dimensions?.width ?? "" },
+                            set: { val in
+                                var d = product.dimensions ?? WCDimensions()
+                                d.width = val
+                                product.dimensions = d
+                            }
+                        )).keyboardType(.decimalPad)
+                        TextField("Height", text: Binding(
+                            get: { product.dimensions?.height ?? "" },
+                            set: { val in
+                                var d = product.dimensions ?? WCDimensions()
+                                d.height = val
+                                product.dimensions = d
+                            }
+                        )).keyboardType(.decimalPad)
+                        TextField("Shipping class", text: Binding(
+                            get: { product.shipping_class ?? "" },
+                            set: { product.shipping_class = $0 }
+                        ))
+                    }
+                    if taxVisible {
+                        Picker("Tax status", selection: Binding(
+                            get: { product.tax_status ?? "taxable" },
+                            set: { product.tax_status = $0 }
+                        )) {
+                            Text("Taxable").tag("taxable")
+                            Text("Shipping only").tag("shipping")
+                            Text("None").tag("none")
+                        }
+                        TextField("Tax class", text: Binding(
+                            get: { product.tax_class ?? "" },
+                            set: { product.tax_class = $0 }
+                        ))
+                    }
+                } label: {
+                    Label("Advanced", systemImage: "slider.horizontal.3")
+                }
+            } footer: {
+                if !showAdvanced {
+                    Text("Tax, shipping and dimensions are hidden by default — tap Advanced to edit.")
+                }
+            }
+        }
+        .navigationTitle(isCreating ? "New Product" : product.name.isEmpty ? "Product" : product.name)
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                Button(isCreating ? "Create" : "Save") {
+                    Task { await save() }
+                }
+                .disabled(saving || product.name.isEmpty)
+            }
+            ToolbarItem(placement: .topBarLeading) {
+                if isCreating {
+                    Button("Cancel") { dismiss() }
+                }
+            }
+        }
+        .overlay {
+            if saving { ProgressView().controlSize(.large) }
+        }
+        .overlay(alignment: .top) {
+            if let error {
+                ErrorBanner(message: error) { self.error = nil }.padding(.top, 4)
+            }
+        }
+        .onChange(of: photoPickerItem) {
+            Task { await loadPickedPhoto() }
+        }
+        .sheet(isPresented: $showCameraPicker) {
+            CameraImagePicker { image in
+                Task { await upload(image: image) }
+            }
+        }
+    }
+
+    private var pricingVisible: Bool {
+        !["grouped"].contains(product.type)
+    }
+    private var inventoryVisible: Bool {
+        !["external", "grouped", "donation", "auction"].contains(product.type)
+    }
+    private var shippingVisible: Bool {
+        !["external", "donation"].contains(product.type)
+    }
+    private var taxVisible: Bool { true }
+
+    @MainActor
+    private func save() async {
+        saving = true; defer { saving = false }
+        do {
+            var patch: [String: Any] = [:]
+            patch["name"]              = product.name
+            patch["type"]              = product.type
+            patch["status"]            = product.status
+            patch["regular_price"]     = product.regular_price ?? ""
+            patch["sale_price"]        = product.sale_price ?? ""
+            patch["description"]       = product.description ?? ""
+            patch["short_description"] = product.short_description ?? ""
+            patch["sku"]               = product.sku ?? ""
+            patch["manage_stock"]      = product.manage_stock ?? false
+            if product.manage_stock == true, let q = product.stock_quantity {
+                patch["stock_quantity"] = q
+            }
+            patch["featured"]          = product.featured ?? false
+            patch["weight"]            = product.weight ?? ""
+            patch["dimensions"]        = [
+                "length": product.dimensions?.length ?? "",
+                "width":  product.dimensions?.width ?? "",
+                "height": product.dimensions?.height ?? ""
+            ]
+            patch["shipping_class"]    = product.shipping_class ?? ""
+            patch["tax_status"]        = product.tax_status ?? "taxable"
+            patch["tax_class"]         = product.tax_class ?? ""
+
+            if let images = product.images, !images.isEmpty {
+                patch["images"] = images.map { ["src": $0.src] }
+            }
+
+            if isCreating {
+                let created = try await WooCommerceService.shared.createProduct(patch)
+                product = created
+                dismiss()
+            } else {
+                let updated = try await WooCommerceService.shared.updateProduct(product.id, patch: patch)
+                product = updated
+            }
+        } catch {
+            self.error = error.localizedDescription
+        }
+    }
+
+    @MainActor
+    private func loadPickedPhoto() async {
+        guard let item = photoPickerItem else { return }
+        do {
+            if let data = try await item.loadTransferable(type: Data.self),
+               let img = UIImage(data: data) {
+                await upload(image: img)
+            }
+        } catch {
+            self.error = error.localizedDescription
+        }
+    }
+
+    @MainActor
+    private func upload(image: UIImage) async {
+        saving = true; defer { saving = false }
+        do {
+            let uploaded = try await WooCommerceService.shared.uploadImage(image)
+            if product.images == nil { product.images = [] }
+            product.images?.insert(uploaded, at: 0)
+        } catch {
+            self.error = "Image upload failed: \(error.localizedDescription)"
+        }
+    }
+}
+
+// MARK: - Camera picker
+
+struct CameraImagePicker: UIViewControllerRepresentable {
+    let onImage: (UIImage) -> Void
+
+    func makeCoordinator() -> Coord { Coord(onImage: onImage) }
+
+    func makeUIViewController(context: Context) -> UIImagePickerController {
+        let p = UIImagePickerController()
+        p.sourceType = UIImagePickerController.isSourceTypeAvailable(.camera) ? .camera : .photoLibrary
+        p.delegate = context.coordinator
+        return p
+    }
+
+    func updateUIViewController(_ uiViewController: UIImagePickerController, context: Context) {}
+
+    final class Coord: NSObject, UIImagePickerControllerDelegate, UINavigationControllerDelegate {
+        let onImage: (UIImage) -> Void
+        init(onImage: @escaping (UIImage) -> Void) { self.onImage = onImage }
+
+        func imagePickerController(
+            _ picker: UIImagePickerController,
+            didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey: Any]
+        ) {
+            if let img = info[.originalImage] as? UIImage { onImage(img) }
+            picker.dismiss(animated: true)
+        }
+        func imagePickerControllerDidCancel(_ picker: UIImagePickerController) {
+            picker.dismiss(animated: true)
+        }
+    }
+}

--- a/ios-app/PTSABoard/Views/Products/ProductsView.swift
+++ b/ios-app/PTSABoard/Views/Products/ProductsView.swift
@@ -1,0 +1,150 @@
+import SwiftUI
+
+struct ProductsView: View {
+    @State private var products: [WCProduct] = []
+    @State private var loading = false
+    @State private var error: String?
+    @State private var search = ""
+    @State private var typeFilter = "any"
+    @State private var statusFilter = "any"
+    @State private var showCreate = false
+
+    private let types = [
+        ("any", "All Types"),
+        ("simple", "Simple"),
+        ("variable", "Variable"),
+        ("grouped", "Grouped"),
+        ("external", "External"),
+        ("auction", "Auction"),
+        ("donation", "Donation")
+    ]
+    private let statuses = [
+        ("any", "Any Status"),
+        ("publish", "Published"),
+        ("draft", "Drafts"),
+        ("private", "Private"),
+        ("pending", "Pending")
+    ]
+
+    var body: some View {
+        Group {
+            if products.isEmpty && !loading {
+                EmptyStateView(
+                    systemImage: "cube.box",
+                    title: "No products",
+                    message: error ?? "Pull to refresh, or try a different filter."
+                )
+            } else {
+                List {
+                    ForEach(products) { product in
+                        NavigationLink(value: product) { ProductRow(product: product) }
+                    }
+                }
+                .listStyle(.insetGrouped)
+            }
+        }
+        .navigationTitle("Products")
+        .searchable(text: $search, prompt: "Search products")
+        .toolbar {
+            ToolbarItem(placement: .topBarLeading) {
+                Menu {
+                    Picker("Type", selection: $typeFilter) {
+                        ForEach(types, id: \.0) { Text($0.1).tag($0.0) }
+                    }
+                    Picker("Status", selection: $statusFilter) {
+                        ForEach(statuses, id: \.0) { Text($0.1).tag($0.0) }
+                    }
+                } label: {
+                    Image(systemName: "line.3.horizontal.decrease.circle")
+                }
+            }
+            ToolbarItem(placement: .topBarTrailing) {
+                Button { showCreate = true } label: {
+                    Image(systemName: "plus.circle.fill")
+                }
+            }
+        }
+        .navigationDestination(for: WCProduct.self) { ProductEditView(product: $0) }
+        .sheet(isPresented: $showCreate) {
+            NavigationStack {
+                ProductEditView(product: WCProduct.newDraft(), isCreating: true)
+            }
+        }
+        .refreshable { await load() }
+        .task(id: "\(typeFilter)-\(statusFilter)") { await load() }
+        .onChange(of: search) {
+            Task {
+                try? await Task.sleep(nanoseconds: 350_000_000)
+                if !Task.isCancelled { await load() }
+            }
+        }
+        .overlay(alignment: .top) {
+            if let error {
+                ErrorBanner(message: error) { self.error = nil }.padding(.top, 4)
+            }
+        }
+        .overlay {
+            if loading && products.isEmpty { ProgressView().controlSize(.large) }
+        }
+    }
+
+    @MainActor
+    private func load() async {
+        loading = true; defer { loading = false }
+        do {
+            products = try await WooCommerceService.shared.products(
+                search: search.isEmpty ? nil : search,
+                type: typeFilter == "any" ? nil : typeFilter,
+                status: statusFilter == "any" ? nil : statusFilter
+            )
+            error = nil
+        } catch {
+            self.error = error.localizedDescription
+        }
+    }
+}
+
+extension WCProduct {
+    static func newDraft() -> WCProduct {
+        WCProduct(
+            id: 0,
+            name: "",
+            type: "simple",
+            status: "draft"
+        )
+    }
+}
+
+private struct ProductRow: View {
+    let product: WCProduct
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 12) {
+            ThumbnailImage(url: product.primaryImageURL, size: 56)
+            VStack(alignment: .leading, spacing: 4) {
+                Text(product.name.isEmpty ? "(Untitled)" : product.name)
+                    .font(.subheadline.weight(.semibold))
+                    .lineLimit(2)
+                HStack(spacing: 6) {
+                    StatusPill(text: product.typeLabel, color: .accentColor)
+                    if product.status != "publish" {
+                        StatusPill(text: product.status.capitalized, color: .orange)
+                    }
+                    if product.on_sale == true {
+                        StatusPill(text: "Sale", color: .pink)
+                    }
+                }
+                HStack {
+                    if let price = product.price, !price.isEmpty {
+                        Text("$\(price)").font(.subheadline).monospacedDigit()
+                    }
+                    Spacer()
+                    if let sku = product.sku, !sku.isEmpty {
+                        Text(sku).font(.caption).foregroundStyle(.secondary)
+                    }
+                }
+            }
+        }
+        .padding(.vertical, 4)
+    }
+}

--- a/ios-app/PTSABoard/Views/RootView.swift
+++ b/ios-app/PTSABoard/Views/RootView.swift
@@ -1,0 +1,45 @@
+import SwiftUI
+
+struct RootView: View {
+    @EnvironmentObject var auth: AuthService
+
+    var body: some View {
+        ZStack {
+            switch auth.state {
+            case .loading:
+                SplashView()
+            case .signedOut:
+                LoginView()
+                    .transition(.opacity)
+            case .signedIn:
+                MainTabView()
+                    .transition(.opacity)
+            case .locked:
+                BiometricLockView()
+                    .transition(.opacity)
+            }
+        }
+        .animation(.easeInOut(duration: 0.25), value: auth.state)
+    }
+}
+
+private struct SplashView: View {
+    var body: some View {
+        ZStack {
+            LinearGradient(
+                colors: [.accentColor.opacity(0.15), .accentColor.opacity(0.4)],
+                startPoint: .topLeading,
+                endPoint: .bottomTrailing
+            )
+            .ignoresSafeArea()
+
+            VStack(spacing: 20) {
+                Image(systemName: "graduationcap.fill")
+                    .font(.system(size: 56, weight: .bold))
+                    .foregroundStyle(.white)
+                ProgressView()
+                    .tint(.white)
+            }
+        }
+    }
+}

--- a/ios-app/PTSABoard/Views/Settings/AuctionEmailSheet.swift
+++ b/ios-app/PTSABoard/Views/Settings/AuctionEmailSheet.swift
@@ -1,0 +1,111 @@
+import SwiftUI
+
+struct AuctionEmailSheet: View {
+    @EnvironmentObject var auth: AuthService
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var toAddresses: String = ""
+    @State private var subject: String = "Wilder PTSA Auction — Items List"
+    @State private var bodyNote: String = "Here's the current list of items in the Wilder PTSA Auction. Tap any item to view or bid."
+    @State private var working = false
+    @State private var error: String?
+    @State private var info: String?
+    @State private var useGraphMail = true
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section("Recipients") {
+                    TextField("comma,separated@wilderptsa.net", text: $toAddresses, axis: .vertical)
+                        .keyboardType(.emailAddress)
+                        .autocorrectionDisabled(true)
+                        .textInputAutocapitalization(.never)
+                        .lineLimit(2...4)
+                    if let me = auth.profile {
+                        Button {
+                            appendEmail(me.email)
+                        } label: { Label("Add me", systemImage: "plus.circle") }
+                    }
+                    Button {
+                        appendEmail("board@\(AppConfig.allowedEmailDomain)")
+                    } label: { Label("Add board@wilderptsa.net", systemImage: "person.3.fill") }
+                }
+
+                Section("Email") {
+                    TextField("Subject", text: $subject)
+                    TextField("Note", text: $bodyNote, axis: .vertical).lineLimit(3...8)
+                }
+
+                Section {
+                    Toggle("Send via my mailbox", isOn: $useGraphMail)
+                } footer: {
+                    Text(useGraphMail
+                         ? "Sends from your Microsoft mailbox (you'll be the From address)."
+                         : "Sends via the website's mailer with the auction-items template.")
+                        .font(.caption)
+                }
+            }
+            .navigationTitle("Auction email")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) { Button("Cancel") { dismiss() } }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Send") { Task { await send() } }
+                        .disabled(toAddresses.trimmingCharacters(in: .whitespaces).isEmpty || working)
+                }
+            }
+            .overlay { if working { ProgressView().controlSize(.large) } }
+            .overlay(alignment: .top) {
+                VStack {
+                    if let error { ErrorBanner(message: error) { self.error = nil } }
+                    if let info {
+                        Text(info)
+                            .font(.footnote)
+                            .padding(10)
+                            .background(.green.opacity(0.9))
+                            .foregroundStyle(.white)
+                            .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+                            .padding(.horizontal)
+                    }
+                }
+            }
+        }
+    }
+
+    private func appendEmail(_ e: String) {
+        let trimmed = toAddresses.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.isEmpty { toAddresses = e }
+        else if !trimmed.contains(e) { toAddresses = trimmed + ", " + e }
+    }
+
+    @MainActor
+    private func send() async {
+        let recipients = toAddresses
+            .split(whereSeparator: { ",;\n ".contains($0) })
+            .map { String($0).trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+        guard !recipients.isEmpty else { return }
+        working = true; defer { working = false }
+
+        do {
+            if useGraphMail {
+                let token = try await auth.graphAccessToken()
+                let html = """
+                <p>\(bodyNote)</p>
+                <p><a href="https://wilderptsa.net/selling/auction/">View all auction items →</a></p>
+                <p style="color:#777;font-size:12px;">Sent from PTSA Board iOS app.</p>
+                """
+                try await GraphService.shared.sendMail(
+                    accessToken: token, subject: subject, bodyHTML: html, to: recipients
+                )
+            } else {
+                try await WordPressService.shared.sendAuctionItemsEmail(to: recipients, subject: subject)
+            }
+            info = "Sent to \(recipients.count) recipient\(recipients.count == 1 ? "" : "s")."
+            try? await Task.sleep(nanoseconds: 1_500_000_000)
+            dismiss()
+        } catch {
+            self.error = error.localizedDescription
+        }
+    }
+}

--- a/ios-app/PTSABoard/Views/Settings/SettingsView.swift
+++ b/ios-app/PTSABoard/Views/Settings/SettingsView.swift
@@ -1,0 +1,171 @@
+import SwiftUI
+
+struct SettingsView: View {
+    @EnvironmentObject var auth: AuthService
+    @EnvironmentObject var theme: ThemeManager
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var info: String?
+    @State private var error: String?
+    @State private var working = false
+    @State private var showAuctionSheet = false
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section {
+                    HStack(spacing: 14) {
+                        AvatarView(profile: auth.profile, size: 56)
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(auth.profile?.displayName ?? "Signed in")
+                                .font(.headline)
+                            if let p = auth.profile {
+                                Text(p.email).font(.subheadline).foregroundStyle(.secondary)
+                                if let title = p.jobTitle, !title.isEmpty {
+                                    Text(title).font(.caption).foregroundStyle(.secondary)
+                                }
+                            }
+                        }
+                    }
+                }
+
+                Section("Account") {
+                    Button {
+                        Task { await resetSelfPw() }
+                    } label: { Label("Reset my WordPress password", systemImage: "key.fill") }
+                    .disabled(working)
+
+                    Button {
+                        Task { await auth.signOut(); dismiss() }
+                    } label: {
+                        Label("Sign out", systemImage: "rectangle.portrait.and.arrow.right")
+                            .foregroundStyle(.red)
+                    }
+                }
+
+                Section("Notifications") {
+                    Button {
+                        showAuctionSheet = true
+                    } label: {
+                        Label("Email auction items list…", systemImage: "envelope.badge.fill")
+                    }
+                    NavigationLink {
+                        EmailTriggersHelpView()
+                    } label: {
+                        Label("Other email triggers", systemImage: "paperplane")
+                    }
+                }
+
+                Section("Appearance") {
+                    Picker("Theme", selection: Binding(
+                        get: { theme.choice },
+                        set: { theme.choice = $0 }
+                    )) {
+                        ForEach(ThemeManager.AppearanceChoice.allCases) { Text($0.label).tag($0) }
+                    }
+                }
+
+                Section("Security") {
+                    HStack {
+                        Label("Biometric unlock", systemImage: biometricIcon)
+                        Spacer()
+                        Text(biometricLabel)
+                            .foregroundStyle(.secondary)
+                    }
+                    Text("Your sign-in is cached on this device. We use \(biometricLabel) to confirm it's still you the next time the app opens.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                Section("About") {
+                    HStack { Text("Version"); Spacer(); Text(appVersion).foregroundStyle(.secondary) }
+                    HStack { Text("WordPress"); Spacer(); Text(AppConfig.wordpressBaseURL.host ?? "").foregroundStyle(.secondary) }
+                    HStack { Text("Calendar"); Spacer(); Text(AppConfig.sharedCalendarMailbox).foregroundStyle(.secondary) }
+                }
+            }
+            .navigationTitle("Settings")
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) { Button("Done") { dismiss() } }
+            }
+            .sheet(isPresented: $showAuctionSheet) {
+                AuctionEmailSheet().environmentObject(auth)
+            }
+            .overlay(alignment: .top) {
+                VStack {
+                    if let error { ErrorBanner(message: error) { self.error = nil } }
+                    if let info {
+                        Text(info)
+                            .font(.footnote)
+                            .padding(10)
+                            .background(.green.opacity(0.9))
+                            .foregroundStyle(.white)
+                            .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+                            .padding(.horizontal)
+                    }
+                }
+            }
+            .overlay { if working { ProgressView().controlSize(.large) } }
+        }
+    }
+
+    private var appVersion: String {
+        let v = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "1.0"
+        let b = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "1"
+        return "\(v) (\(b))"
+    }
+
+    private var biometricIcon: String {
+        switch BiometricService.available {
+        case .faceID: return "faceid"
+        case .touchID: return "touchid"
+        case .opticID: return "opticid"
+        case .none: return "lock"
+        }
+    }
+
+    private var biometricLabel: String {
+        switch BiometricService.available {
+        case .faceID: return "Face ID"
+        case .touchID: return "Touch ID"
+        case .opticID: return "Optic ID"
+        case .none: return "Disabled"
+        }
+    }
+
+    @MainActor
+    private func resetSelfPw() async {
+        working = true; defer { working = false }
+        do {
+            try await WordPressService.shared.triggerSelfPasswordReset()
+            info = "Reset email sent to \(auth.profile?.email ?? "you")."
+            Task { try? await Task.sleep(nanoseconds: 3_000_000_000); info = nil }
+        } catch {
+            self.error = error.localizedDescription
+        }
+    }
+}
+
+// MARK: - Email triggers help
+
+private struct EmailTriggersHelpView: View {
+    var body: some View {
+        List {
+            Section {
+                Text("This screen lets you trigger common bulk emails without opening WordPress.")
+                    .font(.subheadline)
+            }
+            Section("Available triggers") {
+                Label("Auction items bulletin", systemImage: "tag.fill")
+                Label("Order receipt resend (from each order)", systemImage: "envelope.arrow.triangle.branch")
+                Label("Password reset (from any user)", systemImage: "key.fill")
+            }
+            Section {
+                Text("Need a new trigger? Add it in `PTSAService` under the WordPress plugin and we'll surface it here.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .navigationTitle("Email triggers")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+}

--- a/ios-app/PTSABoard/Views/Todo/TodoDetailView.swift
+++ b/ios-app/PTSABoard/Views/Todo/TodoDetailView.swift
@@ -1,0 +1,201 @@
+import SwiftUI
+
+struct TodoDetailView: View {
+    @EnvironmentObject var auth: AuthService
+    @Environment(\.dismiss) private var dismiss
+
+    @State var item: TodoItem?
+    var onChange: (TodoItem) -> Void
+    var onDelete: (Int) -> Void
+
+    @State private var title: String = ""
+    @State private var details: String = ""
+    @State private var priority: TodoPriority = .normal
+    @State private var hasDue: Bool = false
+    @State private var due: Date = .now
+    @State private var saving = false
+    @State private var error: String?
+
+    private var isNew: Bool { item == nil }
+
+    private var isCreator: Bool {
+        guard let me = auth.profile, let item else { return false }
+        return me.email.lowercased() == item.createdByEmail.lowercased()
+    }
+
+    private var canEdit: Bool {
+        isNew || isCreator || (auth.profile?.isTodoAdmin ?? false)
+    }
+
+    private var canToggleComplete: Bool {
+        auth.profile?.isTodoAdmin ?? false
+    }
+
+    var body: some View {
+        Form {
+            Section {
+                if canEdit {
+                    TextField("Title", text: $title)
+                    TextField("Details", text: $details, axis: .vertical).lineLimit(3...10)
+                } else {
+                    if let item {
+                        VStack(alignment: .leading, spacing: 8) {
+                            Text(item.title).font(.headline)
+                            if let d = item.details, !d.isEmpty { Text(d) }
+                        }
+                    }
+                }
+            } header: { Text("Item") }
+
+            Section {
+                if canEdit {
+                    Picker("Priority", selection: $priority) {
+                        ForEach(TodoPriority.allCases) { Text($0.label).tag($0) }
+                    }
+                    Toggle("Has due date", isOn: $hasDue)
+                    if hasDue {
+                        DatePicker("Due", selection: $due, displayedComponents: .date)
+                    }
+                } else if let item {
+                    HStack { Text("Priority"); Spacer(); Text(item.priority.label).foregroundStyle(.secondary) }
+                    if let d = item.dueDate {
+                        HStack { Text("Due"); Spacer(); Text(d, style: .date).foregroundStyle(.secondary) }
+                    }
+                }
+            } header: { Text("Schedule") }
+
+            if let item, !isNew {
+                Section("Meta") {
+                    HStack { Text("Created by"); Spacer(); Text(item.createdByName ?? item.createdByEmail).foregroundStyle(.secondary) }
+                    HStack { Text("Created at"); Spacer(); Text(item.createdAt, style: .date).foregroundStyle(.secondary) }
+                    if item.completed, let by = item.completedByEmail, let at = item.completedAt {
+                        HStack { Text("Completed by"); Spacer(); Text(by).foregroundStyle(.secondary) }
+                        HStack { Text("Completed at"); Spacer(); Text(at, style: .date).foregroundStyle(.secondary) }
+                    }
+                }
+
+                Section("Status") {
+                    if canToggleComplete {
+                        Button {
+                            Task { await toggleComplete() }
+                        } label: {
+                            Label(
+                                item.completed ? "Reopen" : "Mark complete",
+                                systemImage: item.completed ? "arrow.uturn.backward.circle.fill" : "checkmark.circle.fill"
+                            )
+                        }
+                    } else {
+                        Label(
+                            item.completed ? "Completed" : "Open",
+                            systemImage: item.completed ? "checkmark.circle.fill" : "circle"
+                        )
+                        .foregroundStyle(item.completed ? .green : .secondary)
+                    }
+                }
+
+                if isCreator || auth.profile?.isTodoAdmin == true {
+                    Section {
+                        Button(role: .destructive) {
+                            Task { await deleteItem() }
+                        } label: { Label("Delete item", systemImage: "trash") }
+                    }
+                }
+            }
+        }
+        .navigationTitle(isNew ? "New backlog item" : (item?.title ?? "Item"))
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            if isNew {
+                ToolbarItem(placement: .cancellationAction) { Button("Cancel") { dismiss() } }
+                ToolbarItem(placement: .confirmationAction) { Button("Add") { Task { await create() } }.disabled(title.isEmpty || saving) }
+            } else if canEdit {
+                ToolbarItem(placement: .confirmationAction) { Button("Save") { Task { await update() } }.disabled(saving) }
+            }
+        }
+        .overlay { if saving { ProgressView().controlSize(.large) } }
+        .overlay(alignment: .top) {
+            if let error {
+                ErrorBanner(message: error) { self.error = nil }.padding(.top, 4)
+            }
+        }
+        .onAppear { hydrate() }
+    }
+
+    private func hydrate() {
+        guard let item else { return }
+        title = item.title
+        details = item.details ?? ""
+        priority = item.priority
+        if let d = item.dueDate { due = d; hasDue = true }
+    }
+
+    @MainActor
+    private func create() async {
+        guard let me = auth.profile else { return }
+        saving = true; defer { saving = false }
+
+        var draft = TodoItem(
+            title: title,
+            details: details.isEmpty ? nil : details,
+            dueDate: hasDue ? due : nil,
+            createdByEmail: me.email,
+            createdByName: me.displayName,
+            priority: priority
+        )
+
+        do {
+            draft = try await WordPressService.shared.createTodo(draft)
+        } catch {
+            // If the backend isn't available, still add it locally for the session.
+            self.error = "Saved locally only (server: \(error.localizedDescription))."
+        }
+        onChange(draft)
+        dismiss()
+    }
+
+    @MainActor
+    private func update() async {
+        guard var working = item else { return }
+        saving = true; defer { saving = false }
+        working.title = title
+        working.details = details.isEmpty ? nil : details
+        working.dueDate = hasDue ? due : nil
+        working.priority = priority
+        do {
+            working = try await WordPressService.shared.updateTodo(working)
+        } catch {
+            self.error = error.localizedDescription
+        }
+        item = working
+        onChange(working)
+    }
+
+    @MainActor
+    private func toggleComplete() async {
+        guard var working = item, auth.profile?.isTodoAdmin == true else { return }
+        saving = true; defer { saving = false }
+        working.completed.toggle()
+        working.completedAt = working.completed ? Date() : nil
+        working.completedByEmail = working.completed ? auth.profile?.email : nil
+        do {
+            working = try await WordPressService.shared.updateTodo(working)
+        } catch {
+            self.error = error.localizedDescription
+        }
+        item = working
+        onChange(working)
+    }
+
+    @MainActor
+    private func deleteItem() async {
+        guard let item else { return }
+        saving = true; defer { saving = false }
+        do {
+            try await WordPressService.shared.deleteTodo(item.id)
+        } catch {
+            self.error = error.localizedDescription
+        }
+        onDelete(item.id)
+        dismiss()
+    }
+}

--- a/ios-app/PTSABoard/Views/Todo/TodoView.swift
+++ b/ios-app/PTSABoard/Views/Todo/TodoView.swift
@@ -1,0 +1,170 @@
+import SwiftUI
+
+struct TodoView: View {
+    @EnvironmentObject var auth: AuthService
+
+    @State private var items: [TodoItem] = []
+    @State private var loading = false
+    @State private var error: String?
+    @State private var showCreate = false
+    @State private var showCompleted = false
+
+    var body: some View {
+        Group {
+            if visibleItems.isEmpty && !loading {
+                EmptyStateView(
+                    systemImage: "checklist",
+                    title: "Nothing in the backlog",
+                    message: error ?? "Tap + to add a new tech-backlog item."
+                )
+            } else {
+                List {
+                    if !openItems.isEmpty {
+                        Section("Open") {
+                            ForEach(openItems) { item in
+                                NavigationLink(value: item) { TodoRow(item: item) }
+                            }
+                            .onDelete(perform: deleteItems(_:))
+                        }
+                    }
+                    if showCompleted, !completedItems.isEmpty {
+                        Section("Completed") {
+                            ForEach(completedItems) { item in
+                                NavigationLink(value: item) { TodoRow(item: item) }
+                            }
+                            .onDelete(perform: deleteItems(_:))
+                        }
+                    }
+                }
+                .listStyle(.insetGrouped)
+            }
+        }
+        .navigationTitle("Tech Backlog")
+        .navigationDestination(for: TodoItem.self) { item in
+            TodoDetailView(item: item, onChange: handleChange, onDelete: deleteItem)
+                .environmentObject(auth)
+        }
+        .toolbar {
+            ToolbarItem(placement: .topBarLeading) {
+                Menu {
+                    Toggle("Show completed", isOn: $showCompleted)
+                } label: { Image(systemName: "ellipsis.circle") }
+            }
+            ToolbarItem(placement: .topBarTrailing) {
+                Button { showCreate = true } label: { Image(systemName: "plus.circle.fill") }
+            }
+        }
+        .sheet(isPresented: $showCreate) {
+            NavigationStack {
+                TodoDetailView(item: nil, onChange: handleChange, onDelete: deleteItem)
+                    .environmentObject(auth)
+            }
+        }
+        .refreshable { await load() }
+        .task { await load() }
+        .overlay(alignment: .top) {
+            if let error {
+                ErrorBanner(message: error) { self.error = nil }.padding(.top, 4)
+            }
+        }
+        .overlay {
+            if loading && items.isEmpty { ProgressView().controlSize(.large) }
+        }
+    }
+
+    private var openItems: [TodoItem] {
+        items.filter { !$0.completed }
+            .sorted {
+                if $0.priority != $1.priority { return prio($0) > prio($1) }
+                return ($0.dueDate ?? .distantFuture) < ($1.dueDate ?? .distantFuture)
+            }
+    }
+
+    private var completedItems: [TodoItem] {
+        items.filter { $0.completed }
+            .sorted { ($0.completedAt ?? .distantPast) > ($1.completedAt ?? .distantPast) }
+    }
+
+    private var visibleItems: [TodoItem] {
+        showCompleted ? items : openItems
+    }
+
+    private func prio(_ t: TodoItem) -> Int {
+        switch t.priority { case .high: return 2; case .normal: return 1; case .low: return 0 }
+    }
+
+    private func handleChange(_ item: TodoItem) {
+        if let idx = items.firstIndex(where: { $0.id == item.id }) { items[idx] = item }
+        else { items.append(item) }
+    }
+
+    private func deleteItem(_ id: Int) {
+        items.removeAll { $0.id == id }
+    }
+
+    private func deleteItems(_ offsets: IndexSet) {
+        // Only admin can delete arbitrary items
+        guard auth.profile?.isTodoAdmin == true else { return }
+        let arr = visibleItems
+        let ids = offsets.map { arr[$0].id }
+        items.removeAll { ids.contains($0.id) }
+        for id in ids {
+            Task { try? await WordPressService.shared.deleteTodo(id) }
+        }
+    }
+
+    @MainActor
+    private func load() async {
+        loading = true; defer { loading = false }
+        do {
+            items = try await WordPressService.shared.listTodos()
+            error = nil
+        } catch APIError.http(let code, _) where code == 404 {
+            // Endpoint not deployed yet — fall back to local cache so the UI is still useful.
+            error = "Backlog endpoint missing on server (404). Showing local-only items."
+        } catch {
+            self.error = error.localizedDescription
+        }
+    }
+}
+
+private struct TodoRow: View {
+    let item: TodoItem
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 12) {
+            Image(systemName: item.completed ? "checkmark.circle.fill" : "circle")
+                .font(.title3)
+                .foregroundStyle(item.completed ? .green : .secondary)
+                .frame(width: 24)
+            VStack(alignment: .leading, spacing: 4) {
+                Text(item.title)
+                    .font(.subheadline.weight(.semibold))
+                    .strikethrough(item.completed)
+                if let due = item.dueDate {
+                    Label(due.formatted(date: .abbreviated, time: .omitted),
+                          systemImage: "calendar.badge.clock")
+                        .font(.caption)
+                        .foregroundStyle(overdue(due) ? .red : .secondary)
+                }
+                HStack {
+                    StatusPill(text: item.priority.label, color: priorityColor(item.priority))
+                    Text(item.createdByName ?? item.createdByEmail)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
+            }
+        }
+        .padding(.vertical, 4)
+    }
+
+    private func priorityColor(_ p: TodoPriority) -> Color {
+        switch p { case .low: return .gray; case .normal: return .blue; case .high: return .red }
+    }
+
+    private func overdue(_ d: Date) -> Bool {
+        guard !item.completed else { return false }
+        return d < Calendar.current.startOfDay(for: Date())
+    }
+}

--- a/ios-app/PTSABoard/Views/Users/UserDetailView.swift
+++ b/ios-app/PTSABoard/Views/Users/UserDetailView.swift
@@ -1,0 +1,153 @@
+import SwiftUI
+
+struct UserDetailView: View {
+    @State var user: WPUser
+    @State private var error: String?
+    @State private var info: String?
+    @State private var working = false
+    @State private var showRoleEditor = false
+    @State private var roleDraft: Set<String> = []
+
+    private let availableRoles = [
+        "administrator", "editor", "author", "contributor",
+        "shop_manager", "subscriber", "customer"
+    ]
+
+    var body: some View {
+        Form {
+            Section {
+                HStack(alignment: .center, spacing: 16) {
+                    avatar
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text(user.displayName).font(.title3.weight(.bold))
+                        if let e = user.email, !e.isEmpty {
+                            Text(e).font(.subheadline).foregroundStyle(.secondary)
+                        }
+                        if let u = user.username, !u.isEmpty {
+                            Text("@\(u)").font(.caption).foregroundStyle(.secondary)
+                        }
+                    }
+                }
+            }
+
+            Section("Roles") {
+                if let roles = user.roles, !roles.isEmpty {
+                    ForEach(roles, id: \.self) { Text($0.replacingOccurrences(of: "_", with: " ").capitalized) }
+                } else {
+                    Text("No roles").foregroundStyle(.secondary)
+                }
+                Button {
+                    roleDraft = Set(user.roles ?? [])
+                    showRoleEditor = true
+                } label: {
+                    Label("Edit roles", systemImage: "person.crop.circle.badge.checkmark")
+                }
+            }
+
+            Section("Actions") {
+                if let e = user.email, !e.isEmpty {
+                    Button {
+                        UIApplication.shared.open(URL(string: "mailto:\(e)")!)
+                    } label: { Label("Email", systemImage: "envelope") }
+                }
+                Button {
+                    Task { await sendReset() }
+                } label: { Label("Send password reset", systemImage: "key.fill") }
+                .disabled(working || user.email == nil)
+            }
+        }
+        .navigationTitle(user.displayName)
+        .navigationBarTitleDisplayMode(.inline)
+        .overlay { if working { ProgressView().controlSize(.large) } }
+        .overlay(alignment: .top) {
+            VStack {
+                if let error { ErrorBanner(message: error) { self.error = nil } }
+                if let info {
+                    Text(info)
+                        .font(.footnote)
+                        .padding(10)
+                        .background(.green.opacity(0.9))
+                        .foregroundStyle(.white)
+                        .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+                        .padding(.horizontal)
+                }
+            }.padding(.top, 4)
+        }
+        .sheet(isPresented: $showRoleEditor) {
+            NavigationStack {
+                List {
+                    ForEach(availableRoles, id: \.self) { role in
+                        Button {
+                            if roleDraft.contains(role) { roleDraft.remove(role) }
+                            else { roleDraft.insert(role) }
+                        } label: {
+                            HStack {
+                                Text(role.replacingOccurrences(of: "_", with: " ").capitalized)
+                                Spacer()
+                                if roleDraft.contains(role) {
+                                    Image(systemName: "checkmark").foregroundStyle(Color.accentColor)
+                                }
+                            }
+                        }
+                        .buttonStyle(.plain)
+                    }
+                }
+                .navigationTitle("Roles")
+                .navigationBarTitleDisplayMode(.inline)
+                .toolbar {
+                    ToolbarItem(placement: .cancellationAction) { Button("Cancel") { showRoleEditor = false } }
+                    ToolbarItem(placement: .confirmationAction) {
+                        Button("Save") {
+                            Task { showRoleEditor = false; await saveRoles() }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @ViewBuilder private var avatar: some View {
+        ZStack {
+            Circle().fill(Color.accentColor.opacity(0.18))
+            if let url = user.avatarURL {
+                AsyncImage(url: url) { image in
+                    image.resizable().scaledToFill()
+                } placeholder: { Text(initials).font(.title2.bold()).foregroundStyle(Color.accentColor) }
+                .clipShape(Circle())
+            } else {
+                Text(initials).font(.title2.bold()).foregroundStyle(Color.accentColor)
+            }
+        }
+        .frame(width: 64, height: 64)
+    }
+
+    private var initials: String {
+        let parts = user.displayName.split(separator: " ").prefix(2)
+        return parts.compactMap { $0.first }.map { String($0) }.joined().uppercased()
+    }
+
+    @MainActor
+    private func sendReset() async {
+        guard let email = user.email else { return }
+        working = true; defer { working = false }
+        do {
+            try await WordPressService.shared.triggerPasswordReset(forEmail: email)
+            info = "Reset email sent to \(email)."
+            Task { try? await Task.sleep(nanoseconds: 3_000_000_000); info = nil }
+        } catch {
+            self.error = error.localizedDescription
+        }
+    }
+
+    @MainActor
+    private func saveRoles() async {
+        working = true; defer { working = false }
+        do {
+            user = try await WordPressService.shared.updateUserRoles(user.id, roles: Array(roleDraft))
+            info = "Roles updated."
+            Task { try? await Task.sleep(nanoseconds: 2_500_000_000); info = nil }
+        } catch {
+            self.error = error.localizedDescription
+        }
+    }
+}

--- a/ios-app/PTSABoard/Views/Users/UsersView.swift
+++ b/ios-app/PTSABoard/Views/Users/UsersView.swift
@@ -1,0 +1,100 @@
+import SwiftUI
+
+struct UsersView: View {
+    @State private var users: [WPUser] = []
+    @State private var search = ""
+    @State private var loading = false
+    @State private var error: String?
+
+    var body: some View {
+        Group {
+            if users.isEmpty && !loading {
+                EmptyStateView(
+                    systemImage: "person.2.fill",
+                    title: "No users",
+                    message: error ?? "Search by name, username or email."
+                )
+            } else {
+                List {
+                    ForEach(users) { user in
+                        NavigationLink(value: user) {
+                            UserRow(user: user)
+                        }
+                    }
+                }
+                .listStyle(.insetGrouped)
+            }
+        }
+        .navigationTitle("Users")
+        .searchable(text: $search, prompt: "Search users")
+        .navigationDestination(for: WPUser.self) { UserDetailView(user: $0) }
+        .refreshable { await load() }
+        .task { await load() }
+        .onChange(of: search) {
+            Task {
+                try? await Task.sleep(nanoseconds: 350_000_000)
+                if !Task.isCancelled { await load() }
+            }
+        }
+        .overlay(alignment: .top) {
+            if let error {
+                ErrorBanner(message: error) { self.error = nil }.padding(.top, 4)
+            }
+        }
+        .overlay {
+            if loading && users.isEmpty { ProgressView().controlSize(.large) }
+        }
+    }
+
+    @MainActor
+    private func load() async {
+        loading = true; defer { loading = false }
+        do {
+            users = try await WordPressService.shared.searchUsers(search)
+            error = nil
+        } catch {
+            self.error = error.localizedDescription
+        }
+    }
+}
+
+private struct UserRow: View {
+    let user: WPUser
+
+    var body: some View {
+        HStack(spacing: 12) {
+            ZStack {
+                Circle().fill(Color.accentColor.opacity(0.15))
+                if let url = user.avatarURL {
+                    AsyncImage(url: url) { image in
+                        image.resizable().scaledToFill()
+                    } placeholder: {
+                        Text(initials).font(.subheadline.weight(.bold)).foregroundStyle(Color.accentColor)
+                    }
+                    .clipShape(Circle())
+                } else {
+                    Text(initials).font(.subheadline.weight(.bold)).foregroundStyle(Color.accentColor)
+                }
+            }
+            .frame(width: 40, height: 40)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(user.displayName).font(.subheadline.weight(.semibold))
+                if let e = user.email, !e.isEmpty {
+                    Text(e).font(.caption).foregroundStyle(.secondary).lineLimit(1)
+                } else if let u = user.username, !u.isEmpty {
+                    Text("@\(u)").font(.caption).foregroundStyle(.secondary)
+                }
+                if !user.roleLabel.isEmpty {
+                    StatusPill(text: user.roleLabel, color: .accentColor)
+                }
+            }
+        }
+        .padding(.vertical, 2)
+    }
+
+    private var initials: String {
+        let parts = user.displayName.split(separator: " ").prefix(2)
+        return parts.compactMap { $0.first }.map { String($0) }.joined().uppercased()
+    }
+}

--- a/ios-app/README.md
+++ b/ios-app/README.md
@@ -1,0 +1,193 @@
+# PTSA Board — iOS App
+
+A custom-built iOS app for the Wilder PTSA board. Sign in once with your
+`@wilderptsa.net` Microsoft account, then use Face ID after that. Manage
+WooCommerce orders, products, and the shared calendar; trigger password
+resets and bulk emails; and keep a shared technology backlog — all without
+ever touching the WordPress admin UI.
+
+> **Repo location:** this app lives at the `ios-app/` folder of the
+> `pta-tools` monorepo. The matching WordPress plugin endpoints it expects
+> (`/wp-json/ptsa/v1/...`) should be added to the PTA Tools plugin.
+
+---
+
+## Features
+
+- **Microsoft Entra ID sign-in (MSAL)** restricted to `@wilderptsa.net`
+- **Face ID / Touch ID / Optic ID** unlock on subsequent launches
+- **Five tabs** — Orders · Products · Calendar · Users · Tech Backlog
+- **Top-right avatar menu** for personal password reset, theming, email
+  triggers, and sign-out
+- **Custom UI** — SwiftUI, mobile-first, no WordPress chrome anywhere
+- **Per-row contextual actions** in orders (auction pickup info, ticket
+  resends, tax receipts) plus a sheet for sending the auction-items
+  bulletin to a list of recipients
+
+See [`improvements.md`](./improvements.md) for the longer wishlist.
+
+---
+
+## Project layout
+
+```
+ios-app/
+├── PTSABoard.xcodeproj/             # Xcode project (synced groups, Xcode 16+)
+├── PTSABoard/                       # Swift sources
+│   ├── PTSABoardApp.swift           # App entry
+│   ├── Info.plist                   # MSAL URL schemes / Face ID strings
+│   ├── Config/AppConfig.swift       # Tenant, client ID, WP base URL, allow-list
+│   ├── Models/                      # WCOrder, WCProduct, WPUser, GraphEvent, TodoItem, UserProfile
+│   ├── Services/                    # AuthService (MSAL), Graph, Woo, WP, Keychain, Biometric
+│   ├── Views/                       # SwiftUI screens (per tab)
+│   └── Assets.xcassets/             # AppIcon + AccentColor
+├── improvements.md                  # Follow-on ideas
+└── README.md                        # this file
+```
+
+The Xcode project uses [synchronized filesystem groups][synced-groups], so
+Xcode picks up new files automatically when you drop them under
+`PTSABoard/`. There's no `Sources` list to maintain.
+
+[synced-groups]: https://developer.apple.com/wwdc24/10171
+
+---
+
+## Prerequisites
+
+- macOS with **Xcode 16+** and the iOS 17 SDK
+- An Apple Developer team (free or paid) to sign the build
+- Admin access to your Entra ID tenant to register the iOS app
+
+---
+
+## One-time setup
+
+### 1. Register the iOS app in Entra ID
+
+1. Go to <https://entra.microsoft.com> → **Applications** → **App registrations** → **+ New registration**
+2. Name: `Wilder PTSA Board (iOS)`
+3. Supported account types: **Single tenant**
+4. Redirect URI: select **Public client / native (mobile & desktop)** and use
+   `msauth.net.wilderptsa.PTSABoard://auth`
+5. Save, then on **Authentication**:
+   - Add an **iOS / macOS** platform redirect with bundle ID
+     `net.wilderptsa.PTSABoard`. Azure will generate the correct
+     `msauth.<bundle>://auth` URL.
+   - Allow public client flows: **Yes** (mobile flows require this).
+6. On **API permissions**, add delegated Microsoft Graph permissions:
+   - `User.Read`
+   - `User.ReadBasic.All`
+   - `Calendars.ReadWrite.Shared`
+   - `Mail.Send`
+   - `offline_access`, `openid`, `profile`
+   - **Grant admin consent** for the tenant.
+7. Copy the **Application (client) ID** and **Directory (tenant) ID**.
+
+### 2. Generate WooCommerce REST keys
+
+In WP Admin → **WooCommerce → Settings → Advanced → REST API → Add key**:
+- Description: `PTSA Board iOS`
+- User: an account with `shop_manager` (or `administrator`) role
+- Permissions: **Read/Write**
+- Save and copy the consumer key/secret pair.
+
+### 3. Add the matching WordPress endpoints
+
+The app talks to two sets of REST endpoints from your existing PTA Tools
+WordPress plugin:
+
+| Path                                           | Used for                                                              |
+| ---------------------------------------------- | --------------------------------------------------------------------- |
+| `/wp-json/wc/v3/orders` (built-in)             | List, update, refund, note WooCommerce orders                         |
+| `/wp-json/wc/v3/products` (built-in)           | List, create, update products                                         |
+| `/wp-json/ptsa/v1/media`                       | Image upload for product photos (binary body, JPEG)                   |
+| `/wp-json/ptsa/v1/users`                       | Search/list users with `email`/`roles` (Entra JWT auth)               |
+| `/wp-json/ptsa/v1/users/{id}` (PUT)            | Update roles                                                          |
+| `/wp-json/ptsa/v1/users/reset-password`        | Trigger a reset email for a given user                                |
+| `/wp-json/ptsa/v1/users/reset-password-self`   | Trigger a reset for the signed-in user                                |
+| `/wp-json/ptsa/v1/todos`                       | GET/POST tech-backlog items                                           |
+| `/wp-json/ptsa/v1/todos/{id}` (PUT/DELETE)     | Update / delete a backlog item                                        |
+| `/wp-json/ptsa/v1/auction/email-items` (POST)  | Send the bulk "auction items list" email via the website mailer       |
+
+All `ptsa/v1` endpoints should:
+
+1. Require an `Authorization: Bearer <MSAL access token>` header
+2. Validate the JWT against the configured Entra tenant
+3. Confirm `upn`/`preferred_username` ends with `@wilderptsa.net`
+4. Map the caller to a local WP user (e.g. via SSO) for capability checks
+
+The app is graceful when these endpoints aren't deployed yet — it falls
+back to the built-in `wp/v2/users` endpoint where it can, and it surfaces a
+human-readable error in the UI everywhere else. You can therefore ship the
+app and the plugin endpoints separately.
+
+### 4. Fill in `AppConfig.swift`
+
+Open `PTSABoard/Config/AppConfig.swift` and replace the `REPLACE_*` values:
+
+```swift
+static let entraClientId   = "00000000-0000-0000-0000-000000000000"
+static let entraTenantId   = "11111111-1111-1111-1111-111111111111"
+static let wooConsumerKey  = "ck_..."
+static let wooConsumerSecret = "cs_..."
+```
+
+Also update `todoAdminEmails` with the email address(es) that should be
+allowed to mark tech-backlog items as complete.
+
+> **Don't commit secrets.** For shared development we recommend moving
+> these values into a `Config.local.xcconfig` that's gitignored, and
+> reading them back via build-setting injection. The Info.plist already
+> declares a custom URL scheme so a per-developer client ID isn't required.
+
+### 5. Build and run
+
+1. Open `PTSABoard.xcodeproj` in Xcode.
+2. Xcode will resolve Swift Package dependencies (MSAL ~> 1.5).
+3. Select your team under **Signing & Capabilities**.
+4. Pick a physical device (Face ID requires real hardware) and **Run**.
+
+To produce an IPA for ad-hoc distribution: **Product → Archive → Distribute App
+→ Ad Hoc** (or **Development**) and pick your provisioning profile.
+
+To submit to the App Store / TestFlight: **Product → Archive → Distribute App
+→ App Store Connect**.
+
+---
+
+## Architecture notes
+
+- **Auth state machine** — `AuthService` exposes `.loading / .signedOut /
+  .locked / .signedIn`. After the first interactive sign-in we persist a
+  "biometric enrolled" flag in Keychain; on subsequent launches the user
+  lands in `.locked` and must pass Face ID before the silent token
+  refresh runs.
+- **Token strategy** — `graphAccessToken()` always returns a non-expired
+  Microsoft Graph token, refreshing silently when needed. The same token
+  is reused as a Bearer for the custom `ptsa/v1` WordPress endpoints
+  (your plugin validates the JWT server-side).
+- **WooCommerce auth** — Basic auth over HTTPS using the consumer key
+  pair. WooCommerce REST is well-trusted for this so we don't proxy
+  through Graph.
+- **Synced filesystem groups** — adding a `.swift` file under
+  `PTSABoard/` is enough; no `pbxproj` edits required.
+
+---
+
+## Troubleshooting
+
+- **`MSAL init failed`** — usually a typo in `entraClientId` or a
+  missing iOS-platform redirect URI in the registration.
+- **Login succeeds but `Only @wilderptsa.net accounts may use this app`** —
+  expected for any other tenant. Sign out and try a `@wilderptsa.net` account.
+- **`HTTP 401` on WooCommerce calls** — re-check your consumer key/secret
+  and confirm "Read/Write" permission was selected.
+- **`HTTP 404` on `/ptsa/v1/...`** — your plugin doesn't expose that
+  endpoint yet; the UI degrades gracefully.
+
+---
+
+## License
+
+Internal — Wilder PTSA. Not for redistribution.

--- a/ios-app/improvements.md
+++ b/ios-app/improvements.md
@@ -1,0 +1,178 @@
+# PTSA Board iOS — Improvement ideas
+
+A running list of follow-on features and refinements that didn't make it
+into the first cut. None of these are blockers, but most would be high
+value for board operations.
+
+> Convention: each item is sized as **S / M / L / XL** based on rough
+> implementation invasiveness (not calendar time), and tagged with which
+> subsystems are affected.
+
+---
+
+## Payments & merchandise
+
+### Tap-to-Pay on iPhone (M, services + entitlements)
+- Use Apple's [Tap to Pay on iPhone](https://developer.apple.com/tap-to-pay/)
+  to accept in-person card payments at events without a card reader.
+- Requires the `com.apple.developer.proximity-reader.payment.acceptance`
+  entitlement (must be requested from Apple) and integration with one of
+  the supported processors: Stripe, Adyen, Square, or Worldline.
+- Recommended: **Stripe Terminal SDK** because it already integrates well
+  with WooCommerce orders. Workflow: pick an open order in the Orders tab
+  → tap "Charge in-person" → present iPhone to the customer's card → on
+  success, set the WooCommerce order to `processing` (or `completed` for
+  shipping-not-required items).
+
+### Stripe Connect for ad-hoc collections (L, services + backend)
+- For non-WooCommerce collections (raffles at events, room-parent
+  reimbursements, one-off donations), use Stripe Connect to issue
+  short-lived payment links from inside the app — the link opens Apple
+  Pay / Google Pay in a sheet.
+
+### Square / Clover bridge (M, optional)
+- Existing volunteer-led events sometimes already use a Square reader.
+  An "Add Square sale" entry could let board members log those sales into
+  the WooCommerce reporting system after the fact.
+
+---
+
+## Communication
+
+### In-app messaging between board members (M, Graph)
+- Use the [Microsoft Graph Chat API](https://learn.microsoft.com/graph/api/resources/chat)
+  to back a small "Messages" tab. Each conversation maps to a Teams
+  group chat or 1:1 chat. Permission scope: `Chat.ReadWrite`.
+- Cheaper alternative: a single Teams channel ("PTSA Board iOS")
+  surfaced via the `channelMessage` endpoint.
+
+### Smart reply templates (S, models)
+- Saved reply snippets ("Auction pickup info", "Tax-receipt language",
+  "Volunteer ask") that fill the mailto body. Store in
+  `wp-json/ptsa/v1/email-templates`.
+
+### Push notifications (L, infra + backend)
+- Use APNs + a webhook from WordPress for these triggers:
+  - New WooCommerce order placed
+  - Order moved to `failed` / `cancelled`
+  - New tech-backlog item added
+  - New auction bid received
+- Probably cleanest via Azure Notification Hubs since you already use
+  Entra ID.
+
+---
+
+## Orders & products
+
+### Bulk-update orders (S, UI)
+- Multi-select in the Orders list to mark several as `completed` /
+  `cancelled` in one tap.
+
+### Order timeline (S, services)
+- Show the WooCommerce notes feed (`/orders/{id}/notes`) inline on the
+  detail page, with the ability to add a note without leaving the page.
+
+### Print shipping labels (M)
+- Tie into Shippo / ShipStation / Pirate Ship via their REST APIs and
+  print a 4×6 label to an AirPrint-enabled label printer.
+
+### Inventory adjustments from the app (S)
+- Quick `+1` / `-1` stock buttons on each product card when the product
+  has `manage_stock = true`.
+
+### Product variant management (M, UI)
+- The current edit screen handles only top-level fields. Add a Variants
+  section for `type: variable` products to edit per-variant SKU, price,
+  and stock.
+
+### Barcode / QR scanning (S, capture)
+- VisionKit barcode scanner that jumps straight to the matching product
+  by SKU. Useful for room-parent inventory counts.
+
+---
+
+## Calendar
+
+### Multiple shared calendars (S)
+- The PTA Tools plugin already supports multiple calendars in
+  `calendar@wilderptsa.net`. Surface a calendar picker in the Calendar
+  tab and remember the last choice.
+
+### iCal subscribe in-app (S, EventKit)
+- Add a "Subscribe in iOS Calendar" button that registers
+  `webcal://wilderptsa.net/...` so events flow into the system Calendar
+  too.
+
+### RSVP / volunteer slots inline (M)
+- For events that come from the Volunteer Sign-Up module, show slot
+  status inline and let board members claim/unclaim themselves.
+
+---
+
+## Users & roles
+
+### Bulk role changes (S)
+- Multi-select user list → assign a role to many users at once.
+
+### Invite new users (M)
+- Form that creates a WP user via the plugin endpoint and emails them an
+  Entra-issued onboarding link.
+
+### Member directory with photos (S)
+- Use Graph `/users/{id}/photo/$value` to show real headshots in the
+  Users tab. Cache locally.
+
+---
+
+## Tech backlog
+
+### Comments & subscriptions (M, plugin)
+- Threaded comments on each backlog item, with "Subscribe" so the
+  creator gets notified.
+
+### Cross-link with GitHub Issues (M, plugin + UI)
+- Optionally mirror a backlog item to a GitHub Issue in the repo of
+  record (e.g. `pta-tools`).
+
+### Voting / upvotes (S, plugin)
+- A thumbs-up button so board members can signal which backlog items
+  matter most.
+
+---
+
+## App polish
+
+### Glass-card visual theme (S, UI)
+- Adopt iOS 26's Glass material palette across the cards (currently we
+  use system grouped backgrounds).
+
+### Apple Watch companion (XL)
+- A read-only "Today's orders" complication for the school day.
+
+### Widgets (M)
+- Home-screen widgets for "open orders count" and "next 3 calendar
+  events".
+
+### Live Activities (M)
+- Show in-progress auction bids on the Lock Screen during an active
+  auction window.
+
+### Localization (S)
+- Translate strings to Spanish — most PTSA families have at least one
+  parent who'd prefer it.
+
+---
+
+## Security / ops
+
+### Per-user audit log (M, plugin)
+- Every order edit / role change / email trigger should record `who`,
+  `when` and `what` so it's auditable later.
+
+### Conditional Access (S)
+- Add Conditional Access policies in Entra so the iOS app can only be
+  used from compliant devices (e.g. with Intune enrollment).
+
+### App attestation (M)
+- Use `DeviceCheck` / App Attest in the WP plugin to reject calls from
+  non-app callers using a leaked WC key pair.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a custom iOS app for the Wilder PTSA board under `ios-app/`. The app
authenticates `@wilderptsa.net` users via Microsoft Entra ID (MSAL), then
uses Face ID / Touch ID for subsequent unlocks. It speaks directly to
WooCommerce, WordPress, and Microsoft Graph — no WordPress UI involved.

## Tabs

| Tab | What it does |
| --- | --- |
| **Orders** | List recent WooCommerce orders with filter/search. Swipe to complete / hold / cancel. Detail page shows totals, customer, items, and a full Actions section (status changes, refund sheet, add-note sheet, mailto). **Per-line-item contextual actions** include "Send auction pickup info", "Resend tickets", and "Send tax-receipt" based on the item name. |
| **Products** | Browse/filter/search products, edit them, or create new ones. Image picker from photo library *or* camera. Per-product-type field visibility: tax/shipping/dimensions and inventory hide behind an **Advanced** disclosure, and external/grouped/donation/auction products show only the fields that make sense for them. |
| **Calendar** | Read events from `Calendar@wilderptsa.net` via Microsoft Graph; create new events using `Calendars.ReadWrite.Shared` (the existing PTSA delegation model). Date picker drives a list of upcoming events; "Today" toolbar button and pull-to-refresh. |
| **Users** | Search WordPress users, view roles, edit roles, and **trigger password reset emails**. Falls back to `wp/v2/users` when the custom plugin endpoint isn't deployed. |
| **Backlog** | Shared tech-backlog list — anyone with `@wilderptsa.net` can add an item with title, details, priority, and due date. **Only configured admin emails can mark items complete** (configured via `AppConfig.todoAdminEmails`). |

## Avatar / Settings

Top-right avatar on every screen opens the Settings sheet:

- Personal WordPress password reset
- Sign out
- "Email auction items list…" sheet (composes a Graph-sent or
  WordPress-sent bulk email to a comma-separated list of recipients)
- Help screen for other email triggers
- Theme picker (system / light / dark) persisted via `@AppStorage`
- Biometric status banner

## Project layout

```
ios-app/
├── PTSABoard.xcodeproj/             # Xcode 16 synced groups
├── PTSABoard/
│   ├── PTSABoardApp.swift           # App entry, MSAL URL handler
│   ├── Info.plist                   # msauth.net.wilderptsa.PTSABoard scheme
│   ├── Config/AppConfig.swift       # tenant, client ID, allow-list
│   ├── Models/                      # WCOrder, WCProduct, WPUser, GraphEvent, TodoItem, UserProfile
│   ├── Services/                    # AuthService, Graph, Woo, WP, Keychain, Biometric
│   ├── Views/                       # one folder per tab + Common + Auth + Settings
│   └── Assets.xcassets/
├── README.md                        # full setup + deploy instructions
└── improvements.md                  # follow-on ideas (Tap to Pay, Stripe, etc.)
```

The project file uses Xcode 16's **synchronized filesystem groups**, so
adding a new `.swift` file under `PTSABoard/` is enough; no manual
`pbxproj` edits.

## Auth state machine

`AuthService` exposes `.loading / .signedOut / .locked / .signedIn`:

- First launch → interactive MSAL sign-in, store a biometric flag in
  Keychain, hop to `.signedIn`.
- Subsequent launches with a cached MSAL account and biometric flag →
  land in `.locked`, prompt Face ID, then refresh the token silently and
  go to `.signedIn`.
- Tokens are cached in-memory and refreshed via `acquireTokenSilent`
  whenever they're within 60s of expiry.
- The same Graph access token is reused as a `Bearer` for the custom
  `wp-json/ptsa/v1/*` endpoints; the plugin is expected to validate the
  JWT and bind it to a WP user (documented in the README).

## Email-trigger flows

Three places drive email today:

1. **Per-order line item** — heuristic on item name routes to
   pre-filled `mailto:` templates ("auction pickup info",
   "resend tickets", "donation tax receipt").
2. **Settings → Email auction items list** — full sheet with
   recipient list, subject, body note, and a toggle between sending
   from the signed-in user's mailbox (Graph `me/sendMail`) or via the
   website mailer (plugin endpoint `auction/email-items`).
3. **Users → Send password reset** — triggers the plugin's reset
   endpoint server-side.

## Notes on building

- Requires **Xcode 16+** (uses `PBXFileSystemSynchronizedRootGroup`)
- Deployment target: iOS 17
- Adds one SwiftPM dependency: [microsoft-authentication-library-for-objc](https://github.com/AzureAD/microsoft-authentication-library-for-objc) `~> 1.5.0`
- I'm a Linux-side Cloud Agent and can't run `xcodebuild`, so the
  project hasn't been compiled in CI here. The `pbxproj` is hand-written
  but small (one app target, one SPM dep, synced groups) and follows the
  format generated by Xcode 16. Open it in Xcode, fill in the four
  `REPLACE_*` constants in `AppConfig.swift`, sign with your team, and
  Run.

## Backend follow-ups (documented in README)

The plugin in this repo should add a `wp-json/ptsa/v1` namespace with:

- `POST /media` (binary JPEG) — product image upload
- `GET/PUT /users[/:id]` (with email & roles in "edit" context)
- `POST /users/reset-password`, `POST /users/reset-password-self`
- `GET/POST /todos`, `PUT/DELETE /todos/:id`
- `POST /auction/email-items`

Until those exist the affected screens degrade gracefully (clear error
banners, fallbacks to `wp/v2/users` where possible).

## Improvements parking lot

See `ios-app/improvements.md` — highlights:

- **Tap to Pay on iPhone** (Stripe Terminal SDK) to take card payments
  in person at events
- **Stripe Connect** for ad-hoc collections outside WooCommerce
- **In-app board messaging** via Microsoft Graph Chat (Teams)
- **APNs push** on new orders, failed payments, new backlog items, new
  auction bids
- **Bulk actions** in Orders and Users
- **Variant management** for variable products
- **Widgets / Live Activities** (open orders count, next events, active
  auctions)
- **Spanish localization**

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0c7fb10f-53c6-47e4-b6db-a22f6bb323e8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0c7fb10f-53c6-47e4-b6db-a22f6bb323e8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

