### PR TITLE
feat(ios): export saved order reports from Orders tab

### DIFF
--- a/Azure Plugin/includes/class-ptsa-rest-api.php
+++ b/Azure Plugin/includes/class-ptsa-rest-api.php
@@ -152,6 +152,13 @@ class Azure_PTSA_REST_API {
         register_rest_route($ns, '/auction/email-items', array(
             'methods' => 'POST', 'callback' => array($this, 'auction_email_items'), 'permission_callback' => $auth,
         ));
+
+        register_rest_route($ns, '/orders-reports', array(
+            'methods' => 'GET', 'callback' => array($this, 'list_orders_reports'), 'permission_callback' => $auth,
+        ));
+        register_rest_route($ns, '/orders-reports/(?P<id>\d+)/export', array(
+            'methods' => 'GET', 'callback' => array($this, 'export_orders_report'), 'permission_callback' => $auth,
+        ));
     }
 
     /* =================================================================
@@ -1069,6 +1076,114 @@ class Azure_PTSA_REST_API {
             'github_issue_url'    => isset($data['html_url']) ? esc_url_raw((string) $data['html_url']) : null,
             'github_issue_state'  => isset($data['state']) ? sanitize_text_field((string) $data['state']) : null,
         );
+    }
+
+    /* =================================================================
+     * Orders Reports — saved report list + mobile export
+     * ================================================================= */
+
+    public function list_orders_reports(WP_REST_Request $req) {
+        if (!$this->require_orders_reports_cap()) {
+            return $this->forbidden();
+        }
+        if (!$this->load_orders_reports_dependencies()) {
+            return new WP_Error('ptsa_orders_reports_unavailable', 'Orders Reports module is unavailable.', array('status' => 503));
+        }
+
+        $out = array();
+        foreach (Azure_Orders_Reports_Storage::list_all() as $r) {
+            $out[] = array(
+                'id'                 => (int) $r['id'],
+                'name'               => (string) $r['name'],
+                'modified'           => (string) $r['modified'],
+                'last_exported_at'   => !empty($r['last_exported_at']) ? (string) $r['last_exported_at'] : null,
+                'last_exported_rows' => (int) $r['last_exported_rows'],
+            );
+        }
+        return rest_ensure_response($out);
+    }
+
+    public function export_orders_report(WP_REST_Request $req) {
+        if (!$this->require_orders_reports_cap()) {
+            return $this->forbidden();
+        }
+        if (!$this->load_orders_reports_dependencies()) {
+            return new WP_Error('ptsa_orders_reports_unavailable', 'Orders Reports module is unavailable.', array('status' => 503));
+        }
+
+        $report_id = (int) $req['id'];
+        $loaded = Azure_Orders_Reports_Storage::load($report_id);
+        if (!$loaded) {
+            return new WP_Error('ptsa_orders_report_not_found', "Report $report_id not found.", array('status' => 404));
+        }
+
+        $config = $this->orders_report_config_as_of_today($loaded['config']);
+        $query  = new Azure_Orders_Reports_Query();
+        $rows   = $query->count($config);
+
+        $temp = fopen('php://temp', 'w+');
+        if ($temp === false) {
+            return new WP_Error('ptsa_orders_report_export_failed', 'Could not open export buffer.', array('status' => 500));
+        }
+        $exporter = new Azure_Orders_Reports_Export();
+        $exporter->write_to_handle($config, $temp);
+        rewind($temp);
+        $content = stream_get_contents($temp);
+        fclose($temp);
+        if (!is_string($content)) {
+            return new WP_Error('ptsa_orders_report_export_failed', 'Could not read export buffer.', array('status' => 500));
+        }
+
+        Azure_Orders_Reports_Storage::mark_exported($report_id, $rows);
+
+        $safe_name = sanitize_file_name($loaded['name'] . '-' . gmdate('Ymd-His') . '.xls');
+        $response  = new WP_REST_Response($content, 200);
+        $response->header('Content-Type', 'application/vnd.ms-excel; charset=utf-8');
+        $response->header('Content-Disposition', 'attachment; filename="' . $safe_name . '"');
+        $response->header('X-Export-Rows', (string) (int) $rows);
+        $response->header('X-Content-Type-Options', 'nosniff');
+        return $response;
+    }
+
+    private function require_orders_reports_cap() {
+        return current_user_can('manage_woocommerce');
+    }
+
+    private function load_orders_reports_dependencies() {
+        $files = array(
+            'class-orders-reports-cpt.php',
+            'class-orders-reports-columns.php',
+            'class-orders-reports-query.php',
+            'class-orders-reports-export.php',
+            'class-orders-reports-storage.php',
+        );
+        foreach ($files as $f) {
+            $path = AZURE_PLUGIN_PATH . 'includes/' . $f;
+            if (file_exists($path)) {
+                require_once $path;
+            }
+        }
+        return class_exists('Azure_Orders_Reports_Storage')
+            && class_exists('Azure_Orders_Reports_Export')
+            && class_exists('Azure_Orders_Reports_Query');
+    }
+
+    /**
+     * Match the dashboard widget's `run_as_of=today` behaviour: honour
+     * saved presets/filters but force the end boundary to right-now.
+     */
+    private function orders_report_config_as_of_today(array $config) {
+        if (!isset($config['date_range']) || !is_array($config['date_range'])) {
+            $config['date_range'] = array(
+                'from'     => null,
+                'to'       => null,
+                'preset'   => null,
+                'to_today' => true,
+            );
+        } else {
+            $config['date_range']['to_today'] = true;
+        }
+        return $config;
     }
 
     /* =================================================================

--- a/ios-app/PTSABoard/Models/OrdersReport.swift
+++ b/ios-app/PTSABoard/Models/OrdersReport.swift
@@ -1,0 +1,38 @@
+import Foundation
+import SwiftUI
+import UniformTypeIdentifiers
+
+struct PTSAMe: Decodable {
+    let id: Int
+    let email: String
+    let display_name: String
+    let roles: [String]
+}
+
+struct OrdersReportSummary: Decodable, Identifiable {
+    let id: Int
+    let name: String
+    let modified: String?
+    let last_exported_at: String?
+    let last_exported_rows: Int
+}
+
+struct ReportExportDocument: FileDocument {
+    static var readableContentTypes: [UTType] {
+        [UTType(filenameExtension: "xls") ?? .data]
+    }
+
+    var data: Data
+
+    init(data: Data) {
+        self.data = data
+    }
+
+    init(configuration: ReadConfiguration) throws {
+        data = configuration.file.regularFileContents ?? Data()
+    }
+
+    func fileWrapper(configuration: WriteConfiguration) throws -> FileWrapper {
+        FileWrapper(regularFileWithContents: data)
+    }
+}

--- a/ios-app/PTSABoard/Services/APIClient.swift
+++ b/ios-app/PTSABoard/Services/APIClient.swift
@@ -63,8 +63,25 @@ struct APIClient {
         query: [URLQueryItem] = [],
         body: Data? = nil,
         contentType: String = "application/json",
+        accept: String = "application/json",
         auth: AuthMode = .none
     ) async throws -> Data {
+        let (_, data) = try await download(
+            url, method: method, query: query, body: body,
+            contentType: contentType, accept: accept, auth: auth
+        )
+        return data
+    }
+
+    func download(
+        _ url: URL,
+        method: String = "GET",
+        query: [URLQueryItem] = [],
+        body: Data? = nil,
+        contentType: String = "application/json",
+        accept: String = "application/json",
+        auth: AuthMode = .none
+    ) async throws -> (HTTPURLResponse, Data) {
         var comps = URLComponents(url: url, resolvingAgainstBaseURL: false)!
         if !query.isEmpty {
             var items = comps.queryItems ?? []
@@ -75,7 +92,7 @@ struct APIClient {
         req.httpMethod = method
         req.httpBody = body
         if body != nil { req.setValue(contentType, forHTTPHeaderField: "Content-Type") }
-        req.setValue("application/json", forHTTPHeaderField: "Accept")
+        req.setValue(accept, forHTTPHeaderField: "Accept")
         req.setValue("PTSABoard-iOS/1.0", forHTTPHeaderField: "User-Agent")
 
         #if DEBUG
@@ -105,7 +122,7 @@ struct APIClient {
                 #endif
                 throw APIError.http(http.statusCode, snippet)
             }
-            return data
+            return (http, data)
         } catch let err as APIError {
             throw err
         } catch {

--- a/ios-app/PTSABoard/Services/AuthService.swift
+++ b/ios-app/PTSABoard/Services/AuthService.swift
@@ -17,6 +17,7 @@ final class AuthService: ObservableObject {
 
     @Published private(set) var state: AuthState = .loading
     @Published private(set) var profile: UserProfile?
+    @Published private(set) var wpRoles: [String] = []
     @Published private(set) var lastError: String?
     @Published private(set) var signInExpiredAlert = false
 
@@ -30,6 +31,25 @@ final class AuthService: ObservableObject {
     private var shouldLockOnForeground = false
 
     private let biometricEnrolledKey = "biometricEnrolled"
+
+    /// Shop managers and administrators can export saved order reports.
+    var canExportOrdersReports: Bool {
+        let allowed: Set<String> = ["administrator", "shop_manager"]
+        return !Set(wpRoles.map { $0.lowercased() }).isDisjoint(with: allowed)
+    }
+
+    /// Refresh WordPress roles for the signed-in user via `/ptsa/v1/me`.
+    func refreshWordPressRoles() async {
+        guard state == .signedIn else { return }
+        do {
+            let me = try await WordPressService.shared.fetchMe()
+            wpRoles = me.roles
+        } catch {
+            #if DEBUG
+            print("[Auth] refreshWordPressRoles failed: \(error.localizedDescription)")
+            #endif
+        }
+    }
 
     // MARK: - Bootstrap
 
@@ -170,6 +190,7 @@ final class AuthService: ObservableObject {
         }
         self.account = nil
         self.profile = nil
+        self.wpRoles = []
         self.cachedAccessToken = nil
         self.cachedIdToken = nil
         self.cachedTokenExpiry = nil
@@ -223,6 +244,7 @@ final class AuthService: ObservableObject {
                     return
                 }
             }
+            await refreshWordPressRoles()
             state = .signedIn
         } catch {
             logSilentFailure(error, context: "refreshSilent")
@@ -233,17 +255,20 @@ final class AuthService: ObservableObject {
 
     private func refreshSilentAfterLocalUnlock() async -> Bool {
         if hasFreshCachedTokens {
+            await refreshWordPressRoles()
             state = .signedIn
             return true
         }
 
         do {
             _ = try await acquireTokenSilent()
+            await refreshWordPressRoles()
             state = .signedIn
             return true
         } catch {
             logSilentFailure(error, context: "localUnlock")
             if hasFreshCachedTokens {
+                await refreshWordPressRoles()
                 state = .signedIn
                 return true
             }
@@ -318,6 +343,8 @@ final class AuthService: ObservableObject {
         if let data = try? JSONEncoder().encode(me) {
             KeychainService.setData(data, for: "profile.json")
         }
+
+        await refreshWordPressRoles()
 
         if persistBiometric {
             guard await autoEnrollBiometricsIfAppropriate() else {

--- a/ios-app/PTSABoard/Services/WordPressService.swift
+++ b/ios-app/PTSABoard/Services/WordPressService.swift
@@ -19,6 +19,48 @@ final class WordPressService {
         return .bearer(token: token)
     }
 
+    // MARK: - Identity
+
+    func fetchMe() async throws -> PTSAMe {
+        let url = AppConfig.ptsaRestBase.appendingPathComponent("me")
+        return try await api.request(url, auth: try await wpAuth(), as: PTSAMe.self)
+    }
+
+    // MARK: - Orders reports
+
+    func listOrdersReports() async throws -> [OrdersReportSummary] {
+        let url = AppConfig.ptsaRestBase.appendingPathComponent("orders-reports")
+        return try await api.request(url, auth: try await wpAuth(), as: [OrdersReportSummary].self)
+    }
+
+    func exportOrdersReport(id: Int) async throws -> (data: Data, filename: String) {
+        let url = AppConfig.ptsaRestBase.appendingPathComponent("orders-reports/\(id)/export")
+        let (response, data) = try await api.download(
+            url,
+            accept: "application/vnd.ms-excel, application/octet-stream, */*",
+            auth: try await wpAuth()
+        )
+        let filename = Self.filename(from: response) ?? "orders-report.xls"
+        return (data, filename)
+    }
+
+    private static func filename(from response: HTTPURLResponse) -> String? {
+        guard let disposition = response.value(forHTTPHeaderField: "Content-Disposition") else {
+            return nil
+        }
+        for part in disposition.split(separator: ";") {
+            let trimmed = part.trimmingCharacters(in: .whitespaces)
+            if trimmed.lowercased().hasPrefix("filename*=") { continue }
+            guard trimmed.lowercased().hasPrefix("filename=") else { continue }
+            var name = String(trimmed.dropFirst("filename=".count))
+            if name.hasPrefix("\""), name.hasSuffix("\""), name.count >= 2 {
+                name = String(name.dropFirst().dropLast())
+            }
+            return name.isEmpty ? nil : name
+        }
+        return nil
+    }
+
     // MARK: - Users (search / list)
 
     func searchUsers(_ search: String, page: Int = 1, perPage: Int = 25) async throws -> [WPUser] {

--- a/ios-app/PTSABoard/Views/MainTabView.swift
+++ b/ios-app/PTSABoard/Views/MainTabView.swift
@@ -65,9 +65,9 @@ struct MainTabView: View {
             Button {
                 showBacklog = true
             } label: {
-                Image(systemName: "plus.circle.fill")
+                Image(systemName: "list.clipboard.fill")
             }
-            .accessibilityLabel("Add backlog item")
+            .accessibilityLabel("Tech backlog")
         }
         ToolbarItem(placement: .topBarTrailing) {
             Button {

--- a/ios-app/PTSABoard/Views/Orders/OrdersReportsExportSheet.swift
+++ b/ios-app/PTSABoard/Views/Orders/OrdersReportsExportSheet.swift
@@ -1,0 +1,156 @@
+import SwiftUI
+import UniformTypeIdentifiers
+
+struct OrdersReportsExportSheet: View {
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var reports: [OrdersReportSummary] = []
+    @State private var loading = false
+    @State private var error: String?
+    @State private var exportingId: Int?
+    @State private var exportDocument: ReportExportDocument?
+    @State private var showExporter = false
+    @State private var exportFilename = "orders-report.xls"
+
+    var body: some View {
+        NavigationStack {
+            Group {
+                if loading && reports.isEmpty {
+                    ProgressView("Loading reports…")
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                } else if reports.isEmpty {
+                    EmptyStateView(
+                        systemImage: "tablecells",
+                        title: "No Saved Reports",
+                        message: "Saved order reports from PTA Tools will appear here for one-tap export."
+                    )
+                } else {
+                    List(reports) { report in
+                        Button {
+                            Task { await export(report) }
+                        } label: {
+                            ReportRow(report: report, exporting: exportingId == report.id)
+                        }
+                        .disabled(exportingId != nil)
+                    }
+                    .listStyle(.insetGrouped)
+                }
+            }
+            .navigationTitle("Export Report")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Close") { dismiss() }
+                }
+            }
+            .overlay(alignment: .top) {
+                if let error {
+                    ErrorBanner(message: error) { self.error = nil }
+                        .padding(.top, 4)
+                }
+            }
+            .fileExporter(
+                isPresented: $showExporter,
+                document: exportDocument,
+                contentType: UTType(filenameExtension: "xls") ?? .data,
+                defaultFilename: exportFilename
+            ) { result in
+                switch result {
+                case .success:
+                    dismiss()
+                case .failure(let err):
+                    self.error = err.localizedDescription
+                }
+            }
+            .task { await load() }
+        }
+    }
+
+    @MainActor
+    private func load() async {
+        loading = true
+        defer { loading = false }
+        do {
+            reports = try await WordPressService.shared.listOrdersReports()
+            error = nil
+        } catch {
+            self.error = error.localizedDescription
+        }
+    }
+
+    @MainActor
+    private func export(_ report: OrdersReportSummary) async {
+        exportingId = report.id
+        defer { exportingId = nil }
+        do {
+            let result = try await WordPressService.shared.exportOrdersReport(id: report.id)
+            exportDocument = ReportExportDocument(data: result.data)
+            exportFilename = result.filename
+            showExporter = true
+            error = nil
+        } catch {
+            self.error = error.localizedDescription
+        }
+    }
+}
+
+private struct ReportRow: View {
+    let report: OrdersReportSummary
+    let exporting: Bool
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Image(systemName: "tablecells.fill")
+                .font(.title3)
+                .foregroundStyle(.green)
+                .frame(width: 28)
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(report.name)
+                    .font(.headline)
+                    .foregroundStyle(.primary)
+                Text(subtitle)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            Spacer()
+
+            if exporting {
+                ProgressView()
+            } else {
+                Image(systemName: "square.and.arrow.down")
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .padding(.vertical, 4)
+    }
+
+    private var subtitle: String {
+        if let last = report.last_exported_at, !last.isEmpty {
+            let rows = report.last_exported_rows > 0 ? " · \(report.last_exported_rows) rows" : ""
+            return "Last exported \(prettyDate(last))\(rows)"
+        }
+        return "Not exported yet"
+    }
+
+    private func prettyDate(_ raw: String) -> String {
+        let iso = ISO8601DateFormatter()
+        iso.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        if let date = iso.date(from: raw) {
+            return date.formatted(.relative(presentation: .named))
+        }
+        iso.formatOptions = [.withInternetDateTime]
+        if let date = iso.date(from: raw + (raw.hasSuffix("Z") ? "" : "Z")) {
+            return date.formatted(.relative(presentation: .named))
+        }
+        let mysql = DateFormatter()
+        mysql.dateFormat = "yyyy-MM-dd HH:mm:ss"
+        mysql.locale = Locale(identifier: "en_US_POSIX")
+        mysql.timeZone = .current
+        if let date = mysql.date(from: raw) {
+            return date.formatted(.relative(presentation: .named))
+        }
+        return raw
+    }
+}

--- a/ios-app/PTSABoard/Views/Orders/OrdersView.swift
+++ b/ios-app/PTSABoard/Views/Orders/OrdersView.swift
@@ -1,11 +1,13 @@
 import SwiftUI
 
 struct OrdersView: View {
+    @EnvironmentObject var auth: AuthService
     @State private var orders: [WCOrder] = []
     @State private var loading = false
     @State private var error: String?
     @State private var statusFilter = "any"
     @State private var search = ""
+    @State private var showReportsExport = false
 
     private let statuses = [
         ("any", "All"),
@@ -62,6 +64,25 @@ struct OrdersView: View {
                 } label: {
                     Image(systemName: "line.3.horizontal.decrease.circle")
                 }
+            }
+            if auth.canExportOrdersReports {
+                ToolbarItem(placement: .topBarLeading) {
+                    Button {
+                        showReportsExport = true
+                    } label: {
+                        Image(systemName: "tablecells.fill")
+                            .foregroundStyle(.green)
+                    }
+                    .accessibilityLabel("Export saved report")
+                }
+            }
+        }
+        .sheet(isPresented: $showReportsExport) {
+            OrdersReportsExportSheet()
+        }
+        .task {
+            if auth.wpRoles.isEmpty {
+                await auth.refreshWordPressRoles()
             }
         }
         .navigationDestination(for: WCOrder.self) { OrderDetailView(order: $0) }


### PR DESCRIPTION
## Summary

- Adds `GET /wp-json/ptsa/v1/orders-reports` and `GET /wp-json/ptsa/v1/orders-reports/{id}/export` so the iOS app can list saved Orders Reports and download the same `.xls` export the dashboard widget uses (always with `to_today` / run-as-today semantics).
- Orders tab: green spreadsheet toolbar button (shop manager / administrator only) opens a modal of saved reports; tapping one downloads and triggers the native Save to Files flow.
- Global toolbar: tech backlog button icon changed from `+` to clipboard.

## Test plan

- [ ] Deploy plugin REST changes to staging
- [ ] Sign in to iOS app as shop manager or administrator
- [ ] Confirm export icon appears on Orders tab only
- [ ] Open modal — saved reports listed; empty state shows "No Saved Reports"
- [ ] Export a report — file saves via system picker and opens in Excel/Numbers
- [ ] Sign in as a non-shop-manager role — export icon hidden
- [ ] Confirm tech backlog button shows clipboard icon on all tabs


Made with [Cursor](https://cursor.com)